### PR TITLE
シミュレータの検索画面初期表示で検索オプションが開くよう修正

### DIFF
--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -536,7 +536,7 @@ $(function() {
 			}
 		}
 		$("#link-search-submit").data("item-slot", target.data("slot-index"));
-		$("#collapse-search").collapse('hide');
+		$("#collapse-search").collapse('show');
 		$.ajax({
 			url : "/simulator/item/" + target.data("item-class"),
 			type : "GET",

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -21,7 +21,7 @@ class SimulatorController extends Controller {
 
 	public function index(Request $request, Response $response) {
 		$this->title = 'シミュレータ';
-		$this->scripts[] = '/js/simulator.js?id=00026';
+		$this->scripts[] = '/js/simulator.js?id=00029';
 		$item = new ItemModel($this->db, $this->logger);
 		$getParam = $request->getQueryParams();
 		$charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -15,9 +15,9 @@
         </div>
         <div class="modal-body overflow-auto">
           <div>
-            <a href="#collapse-search" class="lemonchiffon" data-toggle="collapse" aria-expanded="false" aria-controls="collapseExample"><i class="fas fa-search"></i>Search</a>
+            <a href="#collapse-search" class="lemonchiffon" data-toggle="collapse" aria-expanded="true" aria-controls="collapseExample"><i class="fas fa-search"></i>Search</a>
           </div>
-          <div class="collapse" id="collapse-search">
+          <div class="collapse show" id="collapse-search">
             <div class="card mb-2 bg-darkblue">
               <div class="card-body p-2">
                 <div class="form-check form-check-inline">


### PR DESCRIPTION
ついでに前回修正分がキャッシュ対策されてなかったのも巻き込み修正