### PR TITLE
ドロップアイテムの管理をグループ方式に変更

### DIFF
--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,13 +1,15 @@
 -- Project Name : Uruluk
--- Date/Time    : 2020/08/08 9:46:22
+-- Date/Time    : 2022/12/20 7:36:13
 -- Author       : Candle
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
 
 /*
+  << 注意！！ >>
   BackupToTempTable, RestoreFromTempTable疑似命令が付加されています。
   これにより、drop table, create table 後もデータが残ります。
   この機能は一時的に $$TableName のような一時テーブルを作成します。
+  この機能は A5:SQL Mk-2でのみ有効であることに注意してください。
 */
 
 -- アクセスカウント
@@ -119,6 +121,28 @@ create table `creature_special_attack` (
   , constraint `creature_special_attack_PKC` primary key (`creature_id`,`special_attack_id`)
 ) comment 'クリーチャースペシャルアタック' ;
 
+-- ドロップアイテムグループ
+--* BackupToTempTable
+drop table if exists `drop_item_group` cascade;
+
+--* RestoreFromTempTable
+create table `drop_item_group` (
+  `drop_item_group_id` INT not null comment 'ドロップアイテムグループID'
+  , `item_id` INT not null comment 'アイテムID'
+  , constraint `drop_item_group_PKC` primary key (`drop_item_group_id`,`item_id`)
+) comment 'ドロップアイテムグループ' ;
+
+-- ドロップアイテムグループ名
+--* BackupToTempTable
+drop table if exists `drop_item_group_name` cascade;
+
+--* RestoreFromTempTable
+create table `drop_item_group_name` (
+  `drop_item_group_id` INT not null AUTO_INCREMENT comment 'ドロップアイテムグループID'
+  , `label` VARCHAR(64) comment 'ラベル'
+  , constraint `drop_item_group_name_PKC` primary key (`drop_item_group_id`)
+) comment 'ドロップアイテムグループ名' ;
+
 -- フロア
 --* BackupToTempTable
 drop table if exists `floor` cascade;
@@ -137,6 +161,17 @@ create table `floor` (
 ) comment 'フロア' ;
 
 alter table `floor` add unique `floor_IX1` (`sort_key`) ;
+
+-- フロアバナナドロップグループ
+--* BackupToTempTable
+drop table if exists `floor_banana_drop_group` cascade;
+
+--* RestoreFromTempTable
+create table `floor_banana_drop_group` (
+  `floor_id` INT not null comment 'フロアID'
+  , `drop_item_group_id` INT not null comment 'ドロップアイテムグループID'
+  , constraint `floor_banana_drop_group_PKC` primary key (`floor_id`,`drop_item_group_id`)
+) comment 'フロアバナナドロップグループ' ;
 
 -- フロアバナナアイテム
 --* BackupToTempTable
@@ -174,6 +209,17 @@ create table `floor_destination` (
   , `destination_floor_id` INT not null comment '移動先フロアID'
   , constraint `floor_destination_PKC` primary key (`floor_id`,`destination_floor_id`)
 ) comment 'フロア移動先' ;
+
+-- フロアドロップグループ
+--* BackupToTempTable
+drop table if exists `floor_drop_group` cascade;
+
+--* RestoreFromTempTable
+create table `floor_drop_group` (
+  `floor_id` INT not null comment 'フロアID'
+  , `drop_item_group_id` INT not null comment 'ドロップアイテムグループID'
+  , constraint `floor_drop_group_PKC` primary key (`floor_id`,`drop_item_group_id`)
+) comment 'フロアドロップグループ' ;
 
 -- フロアドロップアイテム
 --* BackupToTempTable

--- a/src/classes/model/FloorModel.php
+++ b/src/classes/model/FloorModel.php
@@ -164,7 +164,7 @@ class FloorModel extends Model {
 
 	private function getFloorBananaItemList($floorId) {
 		$sql = <<<SQL
-			SELECT
+			SELECT DISTINCT
 			  I.item_id
 			  , IC.name_en item_class
 			  , I.base_item_id
@@ -174,13 +174,16 @@ class FloorModel extends Model {
 			  , I.rarity
 			  , I.image_name
 			FROM
-			  floor_banana_item FI
+			  floor_banana_drop_group FG
+			  INNER JOIN drop_item_group DG
+			    ON FG.drop_item_group_id = DG.drop_item_group_id
 			  INNER JOIN item I
-			    ON FI.item_id = I.item_id
+			    ON DG.item_id = I.item_id
 			  INNER JOIN item_class IC
 			    ON I.item_class_id = IC.item_class_id
 			WHERE
-			  FI.floor_id = :floor_id
+			  FG.floor_id = :floor_id
+			  AND rarity IN ('rare', 'artifact')
 			ORDER BY
 			  I.sort_key
 			  , I.item_id

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -474,15 +474,17 @@ class ItemModel extends Model {
 
 	private function getBananaFloorsByItemId(int $id) {
 		$sql = <<<SQL
-			SELECT
+			SELECT DISTINCT
 			  F.floor_id
 			  , F.short_name
 			FROM
-			  floor_banana_item FI
+			  floor_banana_drop_group FG
+			  INNER JOIN drop_item_group DG
+			    ON FG.drop_item_group_id = DG.drop_item_group_id
 			  INNER JOIN floor F
-			    ON FI.floor_id = F.floor_id
+			    ON FG.floor_id = F.floor_id
 			WHERE
-			  FI.item_id = :id
+			  DG.item_id = :id
 			ORDER BY
 			  F.sort_key
 			SQL;

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -444,15 +444,17 @@ class ItemModel extends Model {
 
 	private function getFloorsByItemId(int $id) {
 		$sql = <<<SQL
-			SELECT
+			SELECT DISTINCT
 			  F.floor_id
 			  , F.short_name
 			FROM
-			  floor_drop_item FI
+			  floor_drop_group FG
 			  INNER JOIN floor F
-			    ON FI.floor_id = F.floor_id
+			    ON FG.floor_id = F.floor_id
+			  INNER JOIN drop_item_group IG
+			    ON IG.drop_item_group_id = FG.drop_item_group_id
 			WHERE
-			  FI.item_id = :id
+			  IG.item_id = :id
 			ORDER BY
 			  F.sort_key
 			SQL;

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -21,42 +21,46 @@ class ItemModel extends Model {
 		'puppet' => 'puppet0.png'
 	];
 
-	private const SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS = "  I.item_id"
-		. "  , I.item_class_id"
-		. "  , IC.name_en item_class_name"
-		. "  , I.image_name"
-		. "  , I.name_en"
-		. "  , I.name_ja"
-		. "  , I.rarity"
-		. "  , I.skill_en"
-		. "  , I.skill_axe_en"
-		. "  , I.skill_sword_en"
-		. "  , I.skill_dagger_en"
-		. "  , I.comment_en"
-		. "  , I.comment_ja"
-		. "  , I.sort_key"
-		. "  , I.price"
-		. "  , A.short_name"
-		. "  , IA.color"
-		. "  , IA.flactuable"
-		. "  , IA.based_source"
-		. "  , IA.attribute_value"
-		. "  , IA.attribute_value_sword"
-		. "  , IA.attribute_value_axe"
-		. "  , IA.attribute_value_dagger"
-		. "  , A.unit"
-		. "  , IA.max_required"
-		. "  , IA.max_required_sword"
-		. "  , IA.max_required_axe"
-		. "  , IA.max_required_dagger ";
+	private const SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS = <<<SQL
+		I.item_id
+		, I.item_class_id
+		, IC.name_en item_class_name
+		, I.image_name
+		, I.name_en
+		, I.name_ja
+		, I.rarity
+		, I.skill_en
+		, I.skill_axe_en
+		, I.skill_sword_en
+		, I.skill_dagger_en
+		, I.comment_en
+		, I.comment_ja
+		, I.sort_key
+		, I.price
+		, A.short_name
+		, IA.color
+		, IA.flactuable
+		, IA.based_source
+		, IA.attribute_value
+		, IA.attribute_value_sword
+		, IA.attribute_value_axe
+		, IA.attribute_value_dagger
+		, A.unit
+		, IA.max_required
+		, IA.max_required_sword
+		, IA.max_required_axe
+		, IA.max_required_dagger
+		SQL;
 
 	public function getItemClassId(string $itemClassName) {
-		$sql = 'SELECT'
-			. '  item_class_id '
-			. 'FROM'
-			. '  item_class '
-			. 'WHERE'
-			. '  name_en = :itemClassName';
+		$sql = <<<SQL
+			SELECT
+			  item_class_id
+			FROM
+			  item_class
+			WHERE
+			  name_en = :itemClassName
+			SQL;
 		$this->logger->debug($sql);
 		$stmt = $this->db->prepare($sql);
 		$stmt->bindParam(':itemClassName', $itemClassName, PDO::PARAM_STR);
@@ -73,12 +77,15 @@ class ItemModel extends Model {
 		foreach ($itemClassNames as $key => $itemClassName) {
 			$sql_itemClassNames[] = ":itemClassName$key";
 		}
-		$sql = 'SELECT'
-			. '  item_class_id '
-			. 'FROM'
-			. '  item_class '
-			. 'WHERE'
-			. '  name_en IN(' . implode($sql_itemClassNames, ', ') . ')';
+		$str_itemClassNames = implode($sql_itemClassNames, ', ');
+		$sql = <<<SQL
+			SELECT
+			  item_class_id
+			FROM
+			  item_class
+			WHERE
+			  name_en IN($str_itemClassNames)
+			SQL;
 		$this->logger->debug($sql);
 		$stmt = $this->db->prepare($sql);
 		foreach ($itemClassNames as $key => $itemClassName) {
@@ -172,22 +179,25 @@ class ItemModel extends Model {
 	}
 
 	public function getItemsByClass(int $itemClassId) {
-		$sql = "SELECT"
-			. self::SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS
-			. "FROM"
-			. "  item I "
-			. "  LEFT JOIN item_class IC "
-			. "    ON I.item_class_id = IC.item_class_id "
-			. "  LEFT JOIN item_attribute IA "
-			. "    ON I.item_id = IA.item_id "
-			. "  LEFT JOIN attribute A "
-			. "    ON IA.attribute_id = A.attribute_id "
-			. "WHERE"
-			. "  I.item_class_id = :itemClassId "
-			. "ORDER BY"
-			. "  I.sort_key"
-			. "  , A.sort_key"
-			. "  , IA.flactuable";
+		$columns = self::SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS;
+		$sql = <<<SQL
+			SELECT
+			  $columns
+			FROM
+			  item I
+			  LEFT JOIN item_class IC
+			    ON I.item_class_id = IC.item_class_id
+			  LEFT JOIN item_attribute IA
+			    ON I.item_id = IA.item_id
+			  LEFT JOIN attribute A
+			    ON IA.attribute_id = A.attribute_id
+			WHERE
+			  I.item_class_id = :itemClassId
+			ORDER BY
+			  I.sort_key
+			  , A.sort_key
+			  , IA.flactuable
+			SQL;
 		$params = [['param' => 'itemClassId', 'var' => $itemClassId, 'type' => PDO::PARAM_INT]];
 		return $this->getItemsObject($sql, $params);
 	}
@@ -205,25 +215,31 @@ class ItemModel extends Model {
 		foreach ($rarities as $key => $rarity) {
 			$sql_rarity[] = ":rarity$key";
 		}
-		$sql = "SELECT"
-			. self::SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS
-			. "FROM"
-			. "  item I "
-			. "  LEFT JOIN item_class IC "
-			. "    ON I.item_class_id = IC.item_class_id "
-			. "  LEFT JOIN item_attribute IA "
-			. "    ON I.item_id = IA.item_id "
-			. "  LEFT JOIN attribute A "
-			. "    ON IA.attribute_id = A.attribute_id "
-			. "WHERE"
-			. "  I.item_class_id IN(" . implode($sql_itemClassId, ", ") . ")";
+		$columns = self::SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS;
+		$str_itemClassId = implode($sql_itemClassId, ", ");
+		$sql = <<<SQL
+			SELECT
+			  $columns
+			FROM
+			  item I
+			  LEFT JOIN item_class IC
+			    ON I.item_class_id = IC.item_class_id
+			  LEFT JOIN item_attribute IA
+			    ON I.item_id = IA.item_id
+			  LEFT JOIN attribute A
+			    ON IA.attribute_id = A.attribute_id
+			WHERE
+			  I.item_class_id IN($str_itemClassId)
+			SQL;
 		if (count($sql_rarity) > 0) {
 			$sql .= "  AND I.rarity IN(" . implode($sql_rarity, ", ") . ")";
 		}
-		$sql .= "ORDER BY"
-			. "  I.sort_key"
-			. "  , A.sort_key"
-			. "  , IA.flactuable";
+		$sql .= <<<SQL
+			ORDER BY
+			  I.sort_key
+			  , A.sort_key
+			  , IA.flactuable
+			SQL;
 		foreach ($itemClassIds as $key => $itemClassId) {
 			$params[] = ['param' => ":itemClassId$key",
 				'var' => $itemClassIds[$key], 'type' => PDO::PARAM_INT];
@@ -261,19 +277,22 @@ class ItemModel extends Model {
 	}
 
 	public function getItemByIdAndClass(int $itemId, string $itemClass) {
-		$sql = "SELECT"
-			. self::SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS
-			. "FROM"
-			. "  item I "
-			. "  LEFT JOIN item_class IC "
-			. "    ON I.item_class_id = IC.item_class_id "
-			. "  LEFT JOIN item_attribute IA "
-			. "    ON I.item_id = IA.item_id "
-			. "  LEFT JOIN attribute A "
-			. "    ON IA.attribute_id = A.attribute_id "
-			. "WHERE"
-			. "  I.item_id = :itemId "
-			. "  AND IC.name_en = :itemClassName ";
+		$columns = self::SQL_COLUMNS_FOR_ITEMS_WITH_ATTRS;
+		$sql = <<<SQL
+			SELECT
+			  $columns
+			FROM
+			  item I
+			  LEFT JOIN item_class IC
+			    ON I.item_class_id = IC.item_class_id
+			  LEFT JOIN item_attribute IA
+			    ON I.item_id = IA.item_id
+			  LEFT JOIN attribute A
+			    ON IA.attribute_id = A.attribute_id
+			WHERE
+			  I.item_id = :itemId
+			  AND IC.name_en = :itemClassName
+			SQL;
 		$params = [
 			['param' => 'itemId', 'var' => $itemId, 'type' => PDO::PARAM_INT],
 			['param' => 'itemClassName', 'var' => $itemClass, 'type' => PDO::PARAM_STR]


### PR DESCRIPTION
- フロアにはドロップアイテムのグループが紐づく
- グループ内に属するアイテムが当該フロアで入手可能になる
- 同一のアイテム群を入手できるフロアを一括で管理できるようにするのが目的
- 現時点ではレアドロップとバナナ交換が対象
- ついでにSQLのリファクタリング
- TODO: 動作に影響がないことを確認し、次のアップデートで既存のフロアドロップアイテムテーブルとフロアバナナアイテムテーブルを削除