### PR TITLE
クリーチャーデータに結界地フェーズ補正の情報を追加

### DIFF
--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,5 +1,5 @@
 -- Project Name : Uruluk
--- Date/Time    : 2022/12/20 7:36:13
+-- Date/Time    : 2023/05/07 2:20:25
 -- Author       : Candle
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
@@ -70,13 +70,24 @@ create table `creature` (
   , `name_ja` VARCHAR(32) comment '名称(日本語)'
   , `min_ad` INT comment '最小攻撃力'
   , `max_ad` INT comment '最大攻撃力'
-  , `as` INT comment '攻撃スピード'
+  , `as` INT comment '攻撃速度'
   , `def` INT comment '防御力'
   , `dex` INT comment '技量'
   , `vit` INT comment '生命力'
+  , `ws` INT comment '移動速度'
   , `voh` INT comment '生命力吸収'
   , `dr` INT comment 'ダメージ反射'
   , `xp` INT comment '経験値'
+  , `tb` BIT(1) default FALSE not null comment '結界地出現'
+  , `tb_ad` DECIMAL(10,1) comment '結界地補正 攻撃力'
+  , `tb_as` DECIMAL(10,1) comment '結界地補正 攻撃速度'
+  , `tb_def` DECIMAL(10,1) comment '結界地補正 防御力'
+  , `tb_dex` DECIMAL(10,1) comment '結界地補正 技量'
+  , `tb_vit` DECIMAL(10,1) comment '結界地補正 生命力'
+  , `tb_ws` DECIMAL(10,1) comment '結界地補正 移動速度'
+  , `tb_voh` DECIMAL(10,1) comment '結界地補正 生命力吸収'
+  , `tb_dr` DECIMAL(10,1) comment '結界地補正 ダメージ反射'
+  , `tb_xp` DECIMAL(10,1) comment '結界地補正 経験値'
   , `note` TEXT comment '説明'
   , `image_name` VARCHAR(32) comment '画像名称'
   , `sort_key` INT not null comment 'ソート順'

--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -1,5 +1,17 @@
 $(function() {
 
+	const setPhaseBoost = function(baseTagId, boostVal, level, isPercentage) {
+		const base = $(baseTagId);
+		if (!base.data("base-val") || base.data("base-val") == 0 || !boostVal) {
+			return;
+		}
+		if (baseTagId == "#detail-as") {
+			base.text(Math.round(base.data("base-val") / (1 + boostVal * level / 100)));
+		} else {
+			base.text(Math.round(base.data("base-val") * (1 + boostVal * level / 100)) + (isPercentage ? '%' : ''));
+		}
+	}
+
 	let autoTransition = false;
 
 	window.addEventListener('popstate', e => {
@@ -34,24 +46,57 @@ $(function() {
 			const creature = data.creature;
 			const imgName = creature.image_name ?
 					creature.image_name : 'creature_noimg.png';
-			const as = creature.as ? creature.as == -1 ? '-' : creature.as : '?';
+			const as = creature.as ? creature.as == 0 ? '-' : creature.as : '?';
 			$("#detail-image").attr('src', '/img/creature/' + imgName);
 			$("#detail-name-ja").text(creature.name_ja);
 			$("#detail-name-en").text(creature.name_en);
-			$("#detail-min-ad").text(creature.min_ad ? creature.min_ad : '?');
-			$("#detail-max-ad").text(creature.max_ad ? creature.max_ad : '?');
-			$("#detail-as").text(as);
-			$("#detail-def").text(creature.def ? creature.def : '?');
-			$("#detail-dex").text(creature.dex ? creature.dex : '?');
-			$("#detail-vit").text(creature.vit ? creature.vit : '?');
-			$("#detail-ws").text(creature.ws ? creature.ws : '?');
-			$("#detail-voh").text((creature.voh ? creature.voh : '?') + '%');
-			$("#detail-dr").text((creature.dr ? creature.dr : '?') + '%');
-			$("#detail-xp").text(creature.xp ? creature.xp : '?');
+			$("#detail-min-ad").text(creature.min_ad ? creature.min_ad : '?')
+				.data("base-val", creature.min_ad);
+			$("#detail-max-ad").text(creature.max_ad ? creature.max_ad : '?')
+				.data("base-val", creature.max_ad);
+			$("#detail-as").text(as)
+				.data("base-val", creature.as);
+			$("#detail-def").text(creature.def ? creature.def : '?')
+				.data("base-val", creature.def);
+			$("#detail-dex").text(creature.dex ? creature.dex : '?')
+				.data("base-val", creature.dex);
+			$("#detail-vit").text(creature.vit ? creature.vit : '?')
+				.data("base-val", creature.vit);
+			$("#detail-ws").text(creature.ws ? creature.ws : '?')
+				.data("base-val", creature.ws);
+			$("#detail-voh").text((creature.voh ? creature.voh : '?') + '%')
+				.data("base-val", creature.voh);
+			$("#detail-dr").text((creature.dr ? creature.dr : '?') + '%')
+				.data("base-val", creature.dr);
+			$("#detail-xp").text(creature.xp ? creature.xp : '?')
+				.data("base-val", creature.xp);
+			$("#tb-ad").text(creature.tb_ad ? creature.tb_ad + '%' : '-')
+				.data("val", creature.tb_ad);
+			$("#tb-as").text(creature.tb_as ? creature.tb_as + '%' : '-')
+				.data("val", creature.tb_as);
+			$("#tb-def").text(creature.tb_def ? creature.tb_def + '%' : '-')
+				.data("val", creature.tb_def);
+			$("#tb-dex").text(creature.tb_dex ? creature.tb_dex + '%' : '-')
+				.data("val", creature.tb_dex);
+			$("#tb-vit").text(creature.tb_vit ? creature.tb_vit + '%' : '-')
+				.data("val", creature.tb_vit);
+			$("#tb-ws").text(creature.tb_ws ? creature.tb_ws + '%' : '-')
+				.data("val", creature.tb_ws);
+			$("#tb-voh").text(creature.tb_voh ? creature.tb_voh + '%' : '-')
+				.data("val", creature.tb_voh);
+			$("#tb-dr").text(creature.tb_dr ? creature.tb_dr + '%' : '-')
+				.data("val", creature.tb_dr);
+			$("#tb-xp").text(creature.tb_xp ? creature.tb_xp + '%' : '-')
+				.data("val", creature.tb_xp);
 			if (creature.boss == 1) {
 				$("#detail-name").addClass("boss");
 			} else {
 				$("#detail-name").removeClass("boss");
+			}
+			if (creature.tb == 1) {
+				$("#detail-tb-boosts,#detail-row-tb-phase").removeClass("d-none");
+			} else {
+				$("#detail-tb-boosts,#detail-row-tb-phase").addClass("d-none");
 			}
 
 			const saTbody = $("#detail-sa");
@@ -112,6 +157,20 @@ $(function() {
 
 			$("#modal-creature").modal("show");
 		});
+	});
+
+	$("select.tb-phase").on('change', function() {
+		const level = $(this).val();
+		setPhaseBoost("#detail-min-ad", $("#tb-ad").data("val"), level, false);
+		setPhaseBoost("#detail-max-ad", $("#tb-ad").data("val"), level, false);
+		setPhaseBoost("#detail-as", $("#tb-as").data("val"), level, false);
+		setPhaseBoost("#detail-def", $("#tb-def").data("val"), level, false);
+		setPhaseBoost("#detail-dex", $("#tb-dex").data("val"), level, false);
+		setPhaseBoost("#detail-vit", $("#tb-vit").data("val"), level, false);
+		setPhaseBoost("#detail-ws", $("#tb-ws").data("val"), level, false);
+		setPhaseBoost("#detail-voh", $("#tb-voh").data("val"), level, true);
+		setPhaseBoost("#detail-dr", $("#tb-dr").data("val"), level, true);
+		setPhaseBoost("#detail-xp", $("#tb-xp").data("val"), level, false);
 	});
 
 	if (location.pathname.split('/').length == 3) {

--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -44,6 +44,7 @@ $(function() {
 			$("#detail-def").text(creature.def ? creature.def : '?');
 			$("#detail-dex").text(creature.dex ? creature.dex : '?');
 			$("#detail-vit").text(creature.vit ? creature.vit : '?');
+			$("#detail-ws").text(creature.ws ? creature.ws : '?');
 			$("#detail-voh").text((creature.voh ? creature.voh : '?') + '%');
 			$("#detail-dr").text((creature.dr ? creature.dr : '?') + '%');
 			$("#detail-xp").text(creature.xp ? creature.xp : '?');

--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -2,13 +2,24 @@ $(function() {
 
 	const setPhaseBoost = function(baseTagId, boostVal, level, isPercentage) {
 		const base = $(baseTagId);
+		const baseTd1 = $("td" + baseTagId);
+		const baseTd2 = $("span" + baseTagId).closest("td");
 		if (!base.data("base-val") || base.data("base-val") == 0 || !boostVal) {
+			baseTd1.removeClass('yellow');
+			baseTd2.removeClass('yellow');
 			return;
 		}
 		if (baseTagId == "#detail-as") {
 			base.text(Math.round(base.data("base-val") / (1 + boostVal * level / 100)));
 		} else {
 			base.text(Math.round(base.data("base-val") * (1 + boostVal * level / 100)) + (isPercentage ? '%' : ''));
+		}
+		if (level > 0) {
+			baseTd1.addClass('yellow');
+			baseTd2.addClass('yellow');
+		} else {
+			baseTd1.removeClass('yellow');
+			baseTd2.removeClass('yellow');
 		}
 	}
 
@@ -154,6 +165,8 @@ $(function() {
 			if (!at && location.pathname.split('/').length != 3) {
 				history.pushState(null, null, '/creatures/' + creatureId);
 			}
+
+			$("select.tb-phase").trigger('change');
 
 			$("#modal-creature").modal("show");
 		});

--- a/src/classes/controller/CreaturesController.php
+++ b/src/classes/controller/CreaturesController.php
@@ -15,7 +15,7 @@ class CreaturesController extends Controller {
 
 	public function index(Request $request, Response $response, array $args) {
 		$this->title = 'クリーチャーデータ';
-		$this->scripts[] = '/js/creature.js?id=00048';
+		$this->scripts[] = '/js/creature.js?id=00066';
 
 		try {
 			$this->db->beginTransaction();

--- a/src/classes/model/CreatureModel.php
+++ b/src/classes/model/CreatureModel.php
@@ -65,9 +65,20 @@ class CreatureModel extends Model {
 			  , def
 			  , dex
 			  , vit
+			  , ws
 			  , voh
 			  , dr
 			  , xp
+			  , tb
+			  , tb_ad
+			  , tb_as
+			  , tb_def
+			  , tb_dex
+			  , tb_vit
+			  , tb_ws
+			  , tb_voh
+			  , tb_dr
+			  , tb_xp
 			  , note
 			  , image_name
 			FROM
@@ -92,9 +103,20 @@ class CreatureModel extends Model {
 				'def' => $result['def'],
 				'dex' => $result['dex'],
 				'vit' => $result['vit'],
+				'ws' => $result['ws'],
 				'voh' => $result['voh'],
 				'dr' => $result['dr'],
 				'xp' => $result['xp'],
+				'tb' => $result['tb'],
+				'tb_ad' => $result['tb_ad'],
+				'tb_as' => $result['tb_as'],
+				'tb_def' => $result['tb_def'],
+				'tb_dex' => $result['tb_dex'],
+				'tb_vit' => $result['tb_vit'],
+				'tb_ws' => $result['tb_ws'],
+				'tb_voh' => $result['tb_voh'],
+				'tb_dr' => $result['tb_dr'],
+				'tb_xp' => $result['tb_xp'],
 				'special_attacks' => $this->getSpecialAttacksByCreatureId($id),
 				'items' => $this->getItemsByCreatureId($id),
 				'floors' => $this->getFloorsByCreatureId($id),

--- a/src/classes/model/CreatureModel.php
+++ b/src/classes/model/CreatureModel.php
@@ -39,14 +39,14 @@ class CreatureModel extends Model {
 				'name_en' => $result['name_en'],
 				'name_ja' => $result['name_ja'],
 				'image_name' => $result['image_name'],
-				'min_ad' => $this->getFormattedStats($result['min_ad']),
-				'max_ad' => $this->getFormattedStats($result['max_ad']),
-				'as' => $this->getFormattedStats($result['as']),
-				'def' => $this->getFormattedStats($result['def']),
-				'dex' => $this->getFormattedStats($result['dex']),
-				'vit' => $this->getFormattedStats($result['vit']),
-				'voh' => $this->getFormattedStats($result['voh']),
-				'dr' => $this->getFormattedStats($result['dr'])
+				'min_ad' => $this->getFormattedStats($result['min_ad'], false),
+				'max_ad' => $this->getFormattedStats($result['max_ad'], false),
+				'as' => $this->getFormattedStats($result['as'], true),
+				'def' => $this->getFormattedStats($result['def'], false),
+				'dex' => $this->getFormattedStats($result['dex'], false),
+				'vit' => $this->getFormattedStats($result['vit'], false),
+				'voh' => $this->getFormattedStats($result['voh'], false),
+				'dr' => $this->getFormattedStats($result['dr'], false)
 			];
 		}
 		return $creatures;
@@ -235,14 +235,15 @@ class CreatureModel extends Model {
 		return $floors;
 	}
 
-	private function getFormattedStats($as) {
-		switch ($as) {
+	private function getFormattedStats($value, bool $enableUndef) {
+		switch ($value) {
 			case null:
 				return '?';
-			case -1:
-				return '-';
+			case 0:
+				if ($enableUndef) return '-';
+				return $value;
 			default:
-				return $as;
+				return $value;
 		}
 	}
 

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -211,15 +211,15 @@
         <tr>
           <td style="padding-left: 33px;">
             <div class="d-table w-100 table-item-attrs">
-          <div class="d-table-row rare">
-            <div class="d-table-cell border border-black text-center w-16">AD</div>
-            <div class="d-table-cell border border-black text-center w-14">AS</div>
-            <div class="d-table-cell border border-black text-center w-14">Def</div>
-            <div class="d-table-cell border border-black text-center w-14">Dex</div>
-            <div class="d-table-cell border border-black text-center w-14">Vit</div>
-            <div class="d-table-cell border border-black text-center w-14">VoH</div>
-            <div class="d-table-cell border border-black text-center w-14">DR</div>
-          </div>
+              <div class="d-table-row rare">
+                <div class="d-table-cell border border-black text-center w-16">AD</div>
+                <div class="d-table-cell border border-black text-center w-14">AS</div>
+                <div class="d-table-cell border border-black text-center w-14">Def</div>
+                <div class="d-table-cell border border-black text-center w-14">Dex</div>
+                <div class="d-table-cell border border-black text-center w-14">Vit</div>
+                <div class="d-table-cell border border-black text-center w-14">VoH</div>
+                <div class="d-table-cell border border-black text-center w-14">DR</div>
+              </div>
             </div>
           </td>
         </tr>

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -43,17 +43,17 @@
               </tr>
               <tr>
                 <td class="text-center">Vit</td>
+                <td class="text-center">WS</td>
                 <td class="text-center">VoH</td>
                 <td class="text-center">DR</td>
                 <td class="text-center">XP</td>
-                <td></td>
               </tr>
               <tr>
                 <td class="text-center" id="detail-vit">15</td>
+                <td class="text-center" id="detail-ws">10</td>
                 <td class="text-center" id="detail-voh">0%</td>
                 <td class="text-center" id="detail-dr">0%</td>
                 <td class="text-center" id="detail-xp">2</td>
-                <td></td>
               </tr>
             </table>
             <table class="table-dark table-striped table-bordered w-100 mb-2">

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -27,6 +27,18 @@
                 <col class="w-20"/>
                 <col class="w-20"/>
               </colgroup>
+              <tr id="detail-row-tb-phase">
+                <td colspan="2">TB Phase</td>
+                <td class="text-right" colspan="3">
+                  <select class="form-control tb-phase p-0 h-auto">
+                    <?php foreach (range(0, 63) as $phaseLevel) : ?>
+                      <option value="<?=$phaseLevel?>">
+                        <?=$phaseLevel * 4 + 1?>～<?=$phaseLevel * 4 + 4?>
+                      </option>
+                    <?php endforeach; ?>
+                  </select>
+                </td>
+              </tr>
               <tr>
                 <td class="text-center" colspan="2">AD</td>
                 <td class="text-center">AS</td>
@@ -55,6 +67,48 @@
                 <td class="text-center" id="detail-dr">0%</td>
                 <td class="text-center" id="detail-xp">2</td>
               </tr>
+            </table>
+            <table class="table-dark table-striped table-bordered w-100 mb-2 d-none" id="detail-tb-boosts">
+              <colgroup>
+                <col class="w-20"/>
+                <col class="w-20"/>
+                <col class="w-20"/>
+                <col class="w-20"/>
+                <col class="w-20"/>
+              </colgroup>
+              <thead>
+                <tr>
+                  <th class="pl-1" colspan="5">TB Phase Boosts</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="text-center" colspan="2">AD</td>
+                  <td class="text-center">AS</td>
+                  <td class="text-center">Def</td>
+                  <td class="text-center">Dex</td>
+                </tr>
+                <tr>
+                  <td class="text-center" id="tb-ad" colspan="2">-</td>
+                  <td class="text-center" id="tb-as">-</td>
+                  <td class="text-center" id="tb-def">-</td>
+                  <td class="text-center" id="tb-dex">-</td>
+                </tr>
+                <tr>
+                  <td class="text-center">Vit</td>
+                  <td class="text-center">WS</td>
+                  <td class="text-center">VoH</td>
+                  <td class="text-center">DR</td>
+                  <td class="text-center">XP</td>
+                </tr>
+                <tr>
+                  <td class="text-center" id="tb-vit">-</td>
+                  <td class="text-center" id="tb-ws">-</td>
+                  <td class="text-center" id="tb-voh">-</td>
+                  <td class="text-center" id="tb-dr">-</td>
+                  <td class="text-center" id="tb-xp">2%</td>
+                </tr>
+              </tbody>
             </table>
             <table class="table-dark table-striped table-bordered w-100 mb-2">
               <thead>
@@ -157,15 +211,15 @@
         <tr>
           <td style="padding-left: 33px;">
             <div class="d-table w-100 table-item-attrs">
-	      <div class="d-table-row rare">
-	        <div class="d-table-cell border border-black text-center w-16">AD</div>
-	        <div class="d-table-cell border border-black text-center w-14">AS</div>
-	        <div class="d-table-cell border border-black text-center w-14">Def</div>
-	        <div class="d-table-cell border border-black text-center w-14">Dex</div>
-	        <div class="d-table-cell border border-black text-center w-14">Vit</div>
-	        <div class="d-table-cell border border-black text-center w-14">VoH</div>
-	        <div class="d-table-cell border border-black text-center w-14">DR</div>
-	      </div>
+          <div class="d-table-row rare">
+            <div class="d-table-cell border border-black text-center w-16">AD</div>
+            <div class="d-table-cell border border-black text-center w-14">AS</div>
+            <div class="d-table-cell border border-black text-center w-14">Def</div>
+            <div class="d-table-cell border border-black text-center w-14">Dex</div>
+            <div class="d-table-cell border border-black text-center w-14">Vit</div>
+            <div class="d-table-cell border border-black text-center w-14">VoH</div>
+            <div class="d-table-cell border border-black text-center w-14">DR</div>
+          </div>
             </div>
           </td>
         </tr>
@@ -176,35 +230,35 @@
             <img class="item-icon" src="/img/creature/<?= $creature['image_name'] == null ? 'creature_noimg.png' : $creature['image_name'] ?>" alt="<?= $creature['name_en'] ?>" />
           </div>
           <div class="d-table-cell w-100 align-top">
-	    <div class="pl-1 <?= $creature['boss'] ? 'boss' : '' ?>">
-	      <div><?= $creature['name_ja'] ?></div>
+            <div class="pl-1 <?= $creature['boss'] ? 'boss' : '' ?>">
+              <div><?= $creature['name_ja'] ?></div>
               <div><?= $creature['name_en'] ?></div>
             </div>
-	      <div class="d-table w-100 table-item-attrs">
-		<div class="d-table-row">
-		  <div class="d-table-cell border border-black text-right w-16">
-		    &nbsp;<?= $creature['min_ad'] ?>~<?= $creature['max_ad'] ?>
-		  </div>
-		  <div class="d-table-cell border border-black text-right w-14">
-                    <?= $creature['as'] ?>
-                  </div>
-		  <div class="d-table-cell border border-black text-right w-14">
-                    <?= $creature['def'] ?>
-                  </div>
-		  <div class="d-table-cell border border-black text-right w-14">
-                    <?= $creature['dex'] ?>
-                  </div>
-		  <div class="d-table-cell border border-black text-right w-14">
-                    <?= $creature['vit'] ?>
-                  </div>
-		  <div class="d-table-cell border border-black text-right w-14">
-                    <?= $creature['voh'] ?>
-                  </div>
-		  <div class="d-table-cell border border-black text-right w-14">
-                    <?= $creature['dr'] ?>
-                  </div>
-		</div>
-	      </div>
+            <div class="d-table w-100 table-item-attrs">
+              <div class="d-table-row">
+                <div class="d-table-cell border border-black text-right w-16">
+                  &nbsp;<?= $creature['min_ad'] ?>~<?= $creature['max_ad'] ?>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <?= $creature['as'] ?>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <?= $creature['def'] ?>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <?= $creature['dex'] ?>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <?= $creature['vit'] ?>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <?= $creature['voh'] ?>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <?= $creature['dr'] ?>
+                </div>
+              </div>
+            </div>
           </div>
         </td>
       </tr>

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -33,7 +33,7 @@
                   <select class="form-control tb-phase p-0 h-auto">
                     <?php foreach (range(0, 63) as $phaseLevel) : ?>
                       <option value="<?=$phaseLevel?>">
-                        <?=$phaseLevel * 4 + 1?>～<?=$phaseLevel * 4 + 4?>
+                        #<?=$phaseLevel * 4 + 1?>&nbsp;～&nbsp;#<?=$phaseLevel * 4 + 4?>
                       </option>
                     <?php endforeach; ?>
                   </select>


### PR DESCRIPTION
# 新機能追加 : 結界地フェーズ補正表示

- 結界地出現フラグがONの場合のみフェーズ補正情報とフェーズ数の選択項目を表示する
- フェーズ数を選択するとそのフェーズでの補正込みでのスタッツを表示する
- フェーズ補正によって上昇しているスタッツは黄色文字で表示する
- フェーズ数の選択はページ遷移しない限り保持され、別のクリーチャーの詳細を開いた場合にも初期表示時点でフェーズ補正が反映される

# 表示項目追加

- 移動速度の項目を新たに追加
- 一覧には表示せず、詳細のみで表示

# 仕様変更

- クリーチャーの攻撃速度の未定義値を-1から0に変更