### PR TITLE
シミュレータにパッシブスキルのスタッツ補正を反映させる機能を追加

### DIFF
--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,6 +1,6 @@
 -- Project Name : Uruluk
--- Date/Time    : 2023/05/07 2:20:25
--- Author       : Candle
+-- Date/Time    : 2023/09/03 2:07:11
+-- Author       : candl
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
 
@@ -13,10 +13,10 @@
 */
 
 -- アクセスカウント
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `access_count` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `access_count` (
   `page_id` INT not null comment 'ページID'
   , `count_date` DATE not null comment 'カウント日付'
@@ -25,10 +25,10 @@ create table `access_count` (
 ) comment 'アクセスカウント' ;
 
 -- 性能
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `attribute` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `attribute` (
   `attribute_id` INT not null AUTO_INCREMENT comment '性能ID'
   , `short_name` VARCHAR(8) comment '略称'
@@ -42,10 +42,10 @@ create table `attribute` (
 alter table `attribute` add unique `attribute_IX1` (`sort_key`) ;
 
 -- ベースアイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `base_item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `base_item` (
   `base_item_id` INT not null AUTO_INCREMENT comment 'ベースアイテムID'
   , `item_class_id` INT not null comment 'アイテムクラスID'
@@ -59,10 +59,10 @@ create table `base_item` (
 alter table `base_item` add unique `base_item_IX1` (`sort_key`) ;
 
 -- クリーチャー
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `creature` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `creature` (
   `creature_id` INT not null AUTO_INCREMENT comment 'クリーチャーID'
   , `boss` BIT(1) default FALSE not null comment 'ボス'
@@ -98,10 +98,10 @@ create unique index `creature_IX1`
   on `creature`(`boss`,`sort_key`);
 
 -- クリーチャードロップアイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `creature_drop_item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `creature_drop_item` (
   `creature_id` INT not null comment 'クリーチャーID'
   , `item_id` INT not null comment 'アイテムID'
@@ -111,10 +111,10 @@ create table `creature_drop_item` (
 alter table `creature_drop_item` add unique `creature_drop_item_IX1` (`item_id`,`creature_id`) ;
 
 -- クリーチャー出現条件
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `creature_pop_event` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `creature_pop_event` (
   `event_id` INT not null AUTO_INCREMENT comment 'イベントID'
   , `note` TEXT comment '説明'
@@ -122,10 +122,10 @@ create table `creature_pop_event` (
 ) comment 'クリーチャー出現条件' ;
 
 -- クリーチャースペシャルアタック
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `creature_special_attack` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `creature_special_attack` (
   `creature_id` INT not null comment 'クリーチャーID'
   , `special_attack_id` INT not null comment 'スペシャルアタックID'
@@ -133,10 +133,10 @@ create table `creature_special_attack` (
 ) comment 'クリーチャースペシャルアタック' ;
 
 -- ドロップアイテムグループ
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `drop_item_group` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `drop_item_group` (
   `drop_item_group_id` INT not null comment 'ドロップアイテムグループID'
   , `item_id` INT not null comment 'アイテムID'
@@ -144,10 +144,10 @@ create table `drop_item_group` (
 ) comment 'ドロップアイテムグループ' ;
 
 -- ドロップアイテムグループ名
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `drop_item_group_name` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `drop_item_group_name` (
   `drop_item_group_id` INT not null AUTO_INCREMENT comment 'ドロップアイテムグループID'
   , `label` VARCHAR(64) comment 'ラベル'
@@ -155,10 +155,10 @@ create table `drop_item_group_name` (
 ) comment 'ドロップアイテムグループ名' ;
 
 -- フロア
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor` (
   `floor_id` INT not null AUTO_INCREMENT comment 'フロアID'
   , `floor_group_id` INT not null comment 'フロアグループID'
@@ -174,10 +174,10 @@ create table `floor` (
 alter table `floor` add unique `floor_IX1` (`sort_key`) ;
 
 -- フロアバナナドロップグループ
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_banana_drop_group` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_banana_drop_group` (
   `floor_id` INT not null comment 'フロアID'
   , `drop_item_group_id` INT not null comment 'ドロップアイテムグループID'
@@ -185,10 +185,10 @@ create table `floor_banana_drop_group` (
 ) comment 'フロアバナナドロップグループ' ;
 
 -- フロアバナナアイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_banana_item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_banana_item` (
   `floor_id` INT not null comment 'フロアID'
   , `item_id` INT not null comment 'アイテムID'
@@ -196,10 +196,10 @@ create table `floor_banana_item` (
 ) comment 'フロアバナナアイテム' ;
 
 -- フロアクリーチャー
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_creature` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_creature` (
   `floor_id` INT not null comment 'フロアID'
   , `event_id` INT default 0 not null comment 'イベントID'
@@ -211,10 +211,10 @@ create unique index `floor_creature_IX1`
   on `floor_creature`(`creature_id`,`floor_id`,`event_id`);
 
 -- フロア移動先
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_destination` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_destination` (
   `floor_id` INT not null comment '移動元フロアID'
   , `destination_floor_id` INT not null comment '移動先フロアID'
@@ -222,10 +222,10 @@ create table `floor_destination` (
 ) comment 'フロア移動先' ;
 
 -- フロアドロップグループ
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_drop_group` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_drop_group` (
   `floor_id` INT not null comment 'フロアID'
   , `drop_item_group_id` INT not null comment 'ドロップアイテムグループID'
@@ -233,10 +233,10 @@ create table `floor_drop_group` (
 ) comment 'フロアドロップグループ' ;
 
 -- フロアドロップアイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_drop_item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_drop_item` (
   `floor_id` INT not null comment 'フロアID'
   , `item_id` INT not null comment 'アイテムID'
@@ -244,10 +244,10 @@ create table `floor_drop_item` (
 ) comment 'フロアドロップアイテム' ;
 
 -- フロアグループ
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_group` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_group` (
   `floor_group_id` INT not null AUTO_INCREMENT comment 'フロアグループID'
   , `name_en` VARCHAR(32) comment '名称(英語)'
@@ -259,10 +259,10 @@ create table `floor_group` (
 alter table `floor_group` add unique `floor_group_IX1` (`sort_key`) ;
 
 -- フロア宝箱
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `floor_treasure` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `floor_treasure` (
   `floor_id` INT not null comment 'フロアID'
   , `item_id` INT not null comment 'アイテムID'
@@ -271,10 +271,10 @@ create table `floor_treasure` (
 ) comment 'フロア宝箱' ;
 
 -- アイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `item` (
   `item_id` INT not null AUTO_INCREMENT comment 'アイテムID'
   , `item_class_id` INT not null comment 'アイテムクラスID'
@@ -284,8 +284,12 @@ create table `item` (
   , `name_en` VARCHAR(64) comment '名称(英語)'
   , `name_ja` VARCHAR(64) comment '名称(日本語)'
   , `rarity` ENUM('common', 'rare', 'artifact') not null comment 'レアリティ'
+  , `skill_id` INT comment 'スキルID'
   , `skill_en` VARCHAR(128) comment 'スキル(英語)'
   , `skill_ja` VARCHAR(64) comment 'スキル(日本語)'
+  , `skill_axe_id` INT comment 'スキルアックスID'
+  , `skill_sword_id` INT comment 'スキルソードID'
+  , `skill_dagger_id` INT comment 'スキルダガーID'
   , `skill_axe_en` VARCHAR(128) comment 'スキルアックス(英語)'
   , `skill_sword_en` VARCHAR(128) comment 'スキルソード(英語)'
   , `skill_dagger_en` VARCHAR(128) comment 'スキルダガー(英語)'
@@ -304,10 +308,10 @@ create unique index `item_IX2`
   on `item`(`item_class_id`,`rarity`,`sort_key`);
 
 -- アイテム性能
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `item_attribute` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `item_attribute` (
   `item_id` INT not null comment 'アイテムID'
   , `attribute_id` INT not null comment '性能ID'
@@ -326,10 +330,10 @@ create table `item_attribute` (
 ) comment 'アイテム性能' ;
 
 -- アイテムブランド
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `item_brand` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `item_brand` (
   `brand_id` INT not null AUTO_INCREMENT comment 'ブランドID'
   , `name_en` VARCHAR(32) comment '名称(英語)'
@@ -341,10 +345,10 @@ create table `item_brand` (
 alter table `item_brand` add unique `item_brand_IX1` (`sort_key`) ;
 
 -- アイテムクラス
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `item_class` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `item_class` (
   `item_class_id` INT not null AUTO_INCREMENT comment 'アイテムクラスID'
   , `name_en` VARCHAR(32) comment '名称(英語)'
@@ -359,11 +363,35 @@ alter table `item_class` add unique `item_class_IX1` (`sort_key`) ;
 
 alter table `item_class` add unique `item_class_IX2` (`shop_sort_key`) ;
 
+-- アイテムスキル
+-- * BackupToTempTable
+drop table if exists `item_skill` cascade;
+
+-- * RestoreFromTempTable
+create table `item_skill` (
+  `skill_id` INT AUTO_INCREMENT comment 'アイテムスキルID'
+  , `name` VARCHAR(64) not null comment 'スキル名'
+  , `trigger_type` ENUM('attack', 'kill', 'damage') not null comment 'トリガー種別'
+  , `kill_trigger_type` ENUM('any', 'dr', 'sa') comment '討伐トリガー種別'
+  , `activation_rate` INT not null comment '発動率(%)'
+  , `trigger_charge` INT not null comment 'トリガーチャージ'
+  , `effect_type` ENUM('heal', 'attribute', 'reduce', 'double', 'splash', 'missile', 'lightning') not null comment '効果種別'
+  , `effect_target_attribute_id` INT comment '対象スタッツ'
+  , `effect_amount` INT comment '効果量(%)'
+  , `effect_duration` INT comment '効果時間(sec)'
+  , `sort_key` INT not null comment 'ソート順'
+  , constraint `item_skill_PKC` primary key (`skill_id`)
+) comment 'アイテムスキル' ;
+
+alter table `item_skill` add unique `item_skill_IX1` (`name`) ;
+
+alter table `item_skill` add unique `item_skill_IX2` (`sort_key`) ;
+
 -- お知らせ
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `news` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `news` (
   `post_date` DATETIME not null comment '投稿日時'
   , `subject` VARCHAR(256) comment '件名'
@@ -372,10 +400,10 @@ create table `news` (
 ) comment 'お知らせ' ;
 
 -- クエスト
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `quest` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `quest` (
   `quest_id` INT not null AUTO_INCREMENT comment 'クエストID'
   , `floor_id` INT not null comment 'フロアID'
@@ -389,10 +417,10 @@ create table `quest` (
 ) comment 'クエスト' ;
 
 -- クエストアイコン
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `quest_icon` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `quest_icon` (
   `quest_id` INT not null comment 'クエストID'
   , `quest_reward` BIT(1) not null comment 'クエスト報酬'
@@ -402,10 +430,10 @@ create table `quest_icon` (
 ) comment 'クエストアイコン' ;
 
 -- クエスト要求アイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `quest_required_item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `quest_required_item` (
   `quest_id` INT not null comment 'クエストID'
   , `item_id` INT not null comment 'アイテムID'
@@ -413,10 +441,10 @@ create table `quest_required_item` (
 ) comment 'クエスト要求アイテム' ;
 
 -- クエスト報酬アイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `quest_reward_item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `quest_reward_item` (
   `quest_id` INT not null comment 'クエストID'
   , `item_id` INT not null comment 'アイテムID'
@@ -424,10 +452,10 @@ create table `quest_reward_item` (
 ) comment 'クエスト報酬アイテム' ;
 
 -- ショップ
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `shop` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `shop` (
   `shop_id` INT not null AUTO_INCREMENT comment 'ショップID'
   , `floor_id` INT not null comment 'フロアID'
@@ -439,10 +467,10 @@ create table `shop` (
 ) comment 'ショップ' ;
 
 -- ショップアイテム
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `shop_item` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `shop_item` (
   `shop_id` INT not null comment 'ショップID'
   , `item_id` INT not null comment 'アイテムID'
@@ -451,10 +479,10 @@ create table `shop_item` (
 ) comment 'ショップアイテム' ;
 
 -- 短縮URL
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `short_url` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `short_url` (
   `short_url_key` VARCHAR(6) not null comment '短縮URLキー'
   , `url` VARCHAR(511) not null comment 'URL'
@@ -466,10 +494,10 @@ create table `short_url` (
 alter table `short_url` add unique `short_url_IX1` (`url`) ;
 
 -- スペシャルアタック
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `special_attack` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `special_attack` (
   `special_attack_id` INT not null AUTO_INCREMENT comment 'スペシャルアタックID'
   , `name` VARCHAR(32) comment '名称'
@@ -479,10 +507,10 @@ create table `special_attack` (
 ) comment 'スペシャルアタック' ;
 
 -- Urulukユーザ
---* BackupToTempTable
+-- * BackupToTempTable
 drop table if exists `uruluk_user` cascade;
 
---* RestoreFromTempTable
+-- * RestoreFromTempTable
 create table `uruluk_user` (
   `user_id` INT not null AUTO_INCREMENT comment 'ユーザID'
   , `login_id` VARCHAR(64) not null comment 'ログインID'

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -46,6 +46,10 @@ a.link-home {
   text-decoration: none;
 }
 
+li.charge-type-skill>input.form-check-input {
+  margin-top: 0.2rem;
+}
+
 .bg-darkgreen {
   background-color: #284044 !important;
 }

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -415,7 +415,7 @@ $(function () {
     if (currentSortAttr == attrName) {
       currentSortOrder *= -1;
     } else {
-      currentSortOrder = (attrName == 'AS' || attrName == 'SA') ? -1 : 1;
+      currentSortOrder = (attrName == 'AS' || attrName == 'SA' || attrName == 'Skill') ? -1 : 1;
     }
     currentSortAttr = attrName;
 
@@ -429,10 +429,10 @@ $(function () {
       let b_val = 0.0;
 
       if (attrName == 'Skill') {
-        a_val = a.skill_en ? a.skill_en : a["skill_" + charaClass + "_en"];
-        b_val = b.skill_en ? b.skill_en : b["skill_" + charaClass + "_en"];
-        if (a_val === null) a_val = "";
-        if (b_val === null) b_val = "";
+        const a_skill = a.skill_en ? a.skill : a["skill_" + charaClass];
+        const b_skill = b.skill_en ? b.skill : b["skill_" + charaClass];
+        a_val = a_skill === null ? 9999999 : a_skill.sort_key;
+        b_val = b_skill === null ? 9999999 : b_skill.sort_key;
       } else {
         a.attributes.forEach(attr => {
           if (attrName == 'AD') {

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -112,7 +112,7 @@ $(function () {
     const charaClass = $("select.character-class").val();
     const attrs = Object.assign({}, characterAttrs[charaClass]);
     $("ul.item-skill").children().remove();
-    let noSkills = true;
+    const skills = [];
 
     // XP, Killsの上限チェック
     if (parseInt($(".character-xp").val()) > parseInt($(".character-xp").attr("max"))) {
@@ -145,8 +145,9 @@ $(function () {
         // スキルの設定
         if (item.skill_en || item["skill_" + $("select.character-class").val() + "_en"]) {
           const skill = $("<li />").text(item.skill_en ? item.skill_en : item["skill_" + $("select.character-class").val() + "_en"]);
-          $("ul.item-skill").append(skill);
-          noSkills = false;
+          const skillCharacterClass = "skill_" + $("select.character-class").val();
+          const skillSortKey = item.skill_en ? item.skill.sort_key : item[skillCharacterClass].sort_key;
+          skills.push({ tag: skill, sortKey: skillSortKey });
         }
 
         // アイテム性能の設定
@@ -173,9 +174,13 @@ $(function () {
       }
     });
 
-    // スキル無し
-    if (noSkills) {
+    // スキルを表示
+    if (skills.length === 0) {
       $("ul.item-skill").append("<li>No Skills</li>");
+    } else {
+      skills.sort((a, b) => a.sortKey - b.sortKey).forEach(skill => {
+        $("ul.item-skill").append(skill.tag);
+      });
     }
 
     // StrをADに加算

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -215,6 +215,8 @@ $(function () {
       const skillAttr = itemSkill.effect_target_attribute;
       if (skillAttr === "sa") {
         attrs[skillAttr] = attrs[skillAttr] + Number(itemSkill.effect_amount);
+      } else if (skillAttr === "as") {
+        attrs[skillAttr] = attrs[skillAttr] * 100 / itemSkill.effect_amount;
       } else {
         attrs[skillAttr] = attrs[skillAttr] * itemSkill.effect_amount / 100;
       }

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -112,8 +112,10 @@ $(function () {
     const charaClass = $("select.character-class").val();
     const attrs = Object.assign({}, characterAttrs[charaClass]);
     $("ul.item-skill").children().remove();
+    $(".table-attributes .skill-reduce-label").addClass("d-none");
     const skills = [];
     const skillCharacterClass = "skill_" + $("select.character-class").val();
+    let reduceDamage = 0;
 
     // XP, Killsの上限チェック
     if (parseInt($(".character-xp").val()) > parseInt($(".character-xp").attr("max"))) {
@@ -157,6 +159,9 @@ $(function () {
             skillTag.append(skillCheckbox);
             skillTag.append($("<label />").attr("for", "item-skill-" + index).addClass("form-check-label").text(skillText));
           } else {
+            if (itemSkill.effect_type === "reduce") {
+              reduceDamage += Number(itemSkill.effect_amount);
+            }
             skillTag.text(skillText);
           }
           const skillSortKey = itemSkill.sort_key;
@@ -202,7 +207,7 @@ $(function () {
       });
     }
 
-    // パッシブスキル効果を計算
+    // チャージ型のパッシブスキル効果を計算
     $(".attr-value").removeClass("item-skill");
     $("input.item-skill-check:checked").toArray().forEach(checkbox => {
       const item = slotItems[$(checkbox).data("slot-index")];
@@ -215,6 +220,13 @@ $(function () {
       }
       $(".attr-value.attr-" + skillAttr + ",.attr-value:has(.attr-" + skillAttr + ")").addClass("item-skill");
     });
+
+    // ダメージ軽減スキル効果を計算
+    if (reduceDamage > 0) {
+      reduceDamageValue = attrs.def * reduceDamage / 100;
+      $(".table-attributes .skill-reduce-label").removeClass("d-none");
+      $(".table-attributes .skill-reduce").text(Math.round(reduceDamageValue));
+    }
 
     // StrをADに加算
     if (attrs.str > 0) {

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -431,8 +431,8 @@ $(function () {
       if (attrName == 'Skill') {
         const a_skill = a.skill_en ? a.skill : a["skill_" + charaClass];
         const b_skill = b.skill_en ? b.skill : b["skill_" + charaClass];
-        a_val = a_skill === null ? 9999999 : a_skill.sort_key;
-        b_val = b_skill === null ? 9999999 : b_skill.sort_key;
+        a_val = a_skill === null ? -9999999 * currentSortOrder : a_skill.sort_key;
+        b_val = b_skill === null ? -9999999 * currentSortOrder : b_skill.sort_key;
       } else {
         a.attributes.forEach(attr => {
           if (attrName == 'AD') {

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -23,7 +23,7 @@ class SimulatorController extends Controller
     public function index(Request $request, Response $response)
     {
         $this->title = 'シミュレータ';
-        $this->scripts[] = '/js/simulator.js?id=00054';
+        $this->scripts[] = '/js/simulator.js?id=00071';
         $item = new ItemModel($this->db, $this->logger);
         $getParam = $request->getQueryParams();
         $charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -488,10 +488,11 @@ class ItemModel extends Model
                     $item['skill']['activation_rate'] = $result['skill_activation_rate'];
                     $item['skill']['trigger_charge'] = $result['skill_trigger_charge'];
                     $item['skill']['effect_type'] = $result['skill_effect_type'];
-                    $item['skill']['effect_target_attribute'] = $result['skill_effect_target_attribute'];
+                    $item['skill']['effect_target_attribute'] = strtolower($result['skill_effect_target_attribute']);
                     $item['skill']['effect_amount'] = $result['skill_effect_amount'];
                     $item['skill']['effect_duration'] = $result['skill_effect_duration'];
                     $item['skill']['sort_key'] = $result['skill_sort_key'];
+                    $item['skill']['enabled'] = false;
                 }
                 if ($result['skill_axe_id'] === null) {
                     $item['skill_axe'] = null;
@@ -504,10 +505,11 @@ class ItemModel extends Model
                     $item['skill_axe']['activation_rate'] = $result['skill_axe_activation_rate'];
                     $item['skill_axe']['trigger_charge'] = $result['skill_axe_trigger_charge'];
                     $item['skill_axe']['effect_type'] = $result['skill_axe_effect_type'];
-                    $item['skill_axe']['effect_target_attribute'] = $result['skill_axe_effect_target_attribute'];
+                    $item['skill_axe']['effect_target_attribute'] = strtolower($result['skill_axe_effect_target_attribute']);
                     $item['skill_axe']['effect_amount'] = $result['skill_axe_effect_amount'];
                     $item['skill_axe']['effect_duration'] = $result['skill_axe_effect_duration'];
                     $item['skill_axe']['sort_key'] = $result['skill_axe_sort_key'];
+                    $item['skill_axe']['enabled'] = false;
                 }
                 if ($result['skill_sword_id'] === null) {
                     $item['skill_sword'] = null;
@@ -520,10 +522,11 @@ class ItemModel extends Model
                     $item['skill_sword']['activation_rate'] = $result['skill_sword_activation_rate'];
                     $item['skill_sword']['trigger_charge'] = $result['skill_sword_trigger_charge'];
                     $item['skill_sword']['effect_type'] = $result['skill_sword_effect_type'];
-                    $item['skill_sword']['effect_target_attribute'] = $result['skill_sword_effect_target_attribute'];
+                    $item['skill_sword']['effect_target_attribute'] = strtolower($result['skill_sword_effect_target_attribute']);
                     $item['skill_sword']['effect_amount'] = $result['skill_sword_effect_amount'];
                     $item['skill_sword']['effect_duration'] = $result['skill_sword_effect_duration'];
                     $item['skill_sword']['sort_key'] = $result['skill_sword_sort_key'];
+                    $item['skill_sword']['enabled'] = false;
                 }
                 if ($result['skill_dagger_id'] === null) {
                     $item['skill_dagger'] = null;
@@ -536,10 +539,11 @@ class ItemModel extends Model
                     $item['skill_dagger']['activation_rate'] = $result['skill_dagger_activation_rate'];
                     $item['skill_dagger']['trigger_charge'] = $result['skill_dagger_trigger_charge'];
                     $item['skill_dagger']['effect_type'] = $result['skill_dagger_effect_type'];
-                    $item['skill_dagger']['effect_target_attribute'] = $result['skill_dagger_effect_target_attribute'];
+                    $item['skill_dagger']['effect_target_attribute'] = strtolower($result['skill_dagger_effect_target_attribute']);
                     $item['skill_dagger']['effect_amount'] = $result['skill_dagger_effect_amount'];
                     $item['skill_dagger']['effect_duration'] = $result['skill_dagger_effect_duration'];
                     $item['skill_dagger']['sort_key'] = $result['skill_dagger_sort_key'];
+                    $item['skill_dagger']['enabled'] = false;
                 }
                 $item['comment_en'] = $result['comment_en'];
                 $item['comment_ja'] = $result['comment_ja'];

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -34,6 +34,50 @@ class ItemModel extends Model
         , I.skill_axe_en
         , I.skill_sword_en
         , I.skill_dagger_en
+        , S.skill_id
+        , S.name skill_name
+        , S.trigger_type skill_trigger_type
+        , S.kill_trigger_type skill_kill_trigger_type
+        , S.activation_rate skill_activation_rate
+        , S.trigger_charge skill_trigger_charge
+        , S.effect_type skill_effect_type
+        , SAT.short_name skill_effect_target_attribute
+        , S.effect_amount skill_effect_amount
+        , S.effect_duration skill_effect_duration
+        , S.sort_key skill_sort_key
+        , SA.skill_id skill_axe_id
+        , SA.name skill_axe_name
+        , SA.trigger_type skill_axe_trigger_type
+        , SA.kill_trigger_type skill_axe_kill_trigger_type
+        , SA.activation_rate skill_axe_activation_rate
+        , SA.trigger_charge skill_axe_trigger_charge
+        , SA.effect_type skill_axe_effect_type
+        , SAAT.short_name skill_axe_effect_target_attribute
+        , SA.effect_amount skill_axe_effect_amount
+        , SA.effect_duration skill_axe_effect_duration
+        , SA.sort_key skill_axe_sort_key
+        , SS.skill_id skill_sword_id
+        , SS.name skill_sword_name
+        , SS.trigger_type skill_sword_trigger_type
+        , SS.kill_trigger_type skill_sword_kill_trigger_type
+        , SS.activation_rate skill_sword_activation_rate
+        , SS.trigger_charge skill_sword_trigger_charge
+        , SS.effect_type skill_sword_effect_type
+        , SSAT.short_name skill_sword_effect_target_attribute
+        , SS.effect_amount skill_sword_effect_amount
+        , SS.effect_duration skill_sword_effect_duration
+        , SS.sort_key skill_sword_sort_key
+        , SD.skill_id skill_dagger_id
+        , SD.name skill_dagger_name
+        , SD.trigger_type skill_dagger_trigger_type
+        , SD.kill_trigger_type skill_dagger_kill_trigger_type
+        , SD.activation_rate skill_dagger_activation_rate
+        , SD.trigger_charge skill_dagger_trigger_charge
+        , SD.effect_type skill_dagger_effect_type
+        , SDAT.short_name skill_dagger_effect_target_attribute
+        , SD.effect_amount skill_dagger_effect_amount
+        , SD.effect_duration skill_dagger_effect_duration
+        , SD.sort_key skill_dagger_sort_key
         , I.comment_en
         , I.comment_ja
         , I.sort_key
@@ -195,6 +239,22 @@ class ItemModel extends Model
                 item I
                 LEFT JOIN item_class IC
                     ON I.item_class_id = IC.item_class_id
+                LEFT JOIN item_skill S
+                    ON I.skill_id = S.skill_id
+                LEFT JOIN attribute SAT
+                    ON S.effect_target_attribute_id = SAT.attribute_id
+                LEFT JOIN item_skill SA
+                    ON I.skill_axe_id = SA.skill_id
+                LEFT JOIN attribute SAAT
+                    ON SA.effect_target_attribute_id = SAAT.attribute_id
+                LEFT JOIN item_skill SS
+                    ON I.skill_sword_id = SS.skill_id
+                LEFT JOIN attribute SSAT
+                    ON SS.effect_target_attribute_id = SSAT.attribute_id
+                LEFT JOIN item_skill SD
+                    ON I.skill_dagger_id = SD.skill_id
+                LEFT JOIN attribute SDAT
+                    ON SD.effect_target_attribute_id = SDAT.attribute_id
                 LEFT JOIN item_attribute IA
                     ON I.item_id = IA.item_id
                 LEFT JOIN attribute A
@@ -234,6 +294,22 @@ class ItemModel extends Model
                 item I
                 LEFT JOIN item_class IC
                     ON I.item_class_id = IC.item_class_id
+                LEFT JOIN item_skill S
+                    ON I.skill_id = S.skill_id
+                LEFT JOIN attribute SAT
+                    ON S.effect_target_attribute_id = SAT.attribute_id
+                LEFT JOIN item_skill SA
+                    ON I.skill_axe_id = SA.skill_id
+                LEFT JOIN attribute SAAT
+                    ON SA.effect_target_attribute_id = SAAT.attribute_id
+                LEFT JOIN item_skill SS
+                    ON I.skill_sword_id = SS.skill_id
+                LEFT JOIN attribute SSAT
+                    ON SS.effect_target_attribute_id = SSAT.attribute_id
+                LEFT JOIN item_skill SD
+                    ON I.skill_dagger_id = SD.skill_id
+                LEFT JOIN attribute SDAT
+                    ON SD.effect_target_attribute_id = SDAT.attribute_id
                 LEFT JOIN item_attribute IA
                     ON I.item_id = IA.item_id
                 LEFT JOIN attribute A
@@ -275,6 +351,22 @@ class ItemModel extends Model
                 item I
                 LEFT JOIN item_class IC
                     ON I.item_class_id = IC.item_class_id
+                LEFT JOIN item_skill S
+                    ON I.skill_id = S.skill_id
+                LEFT JOIN attribute SAT
+                    ON S.effect_target_attribute_id = SAT.attribute_id
+                LEFT JOIN item_skill SA
+                    ON I.skill_axe_id = SA.skill_id
+                LEFT JOIN attribute SAAT
+                    ON SA.effect_target_attribute_id = SAAT.attribute_id
+                LEFT JOIN item_skill SS
+                    ON I.skill_sword_id = SS.skill_id
+                LEFT JOIN attribute SSAT
+                    ON SS.effect_target_attribute_id = SSAT.attribute_id
+                LEFT JOIN item_skill SD
+                    ON I.skill_dagger_id = SD.skill_id
+                LEFT JOIN attribute SDAT
+                    ON SD.effect_target_attribute_id = SDAT.attribute_id
                 LEFT JOIN item_attribute IA
                     ON I.item_id = IA.item_id
                 LEFT JOIN attribute A
@@ -301,6 +393,22 @@ class ItemModel extends Model
                 item I
                 LEFT JOIN item_class IC
                     ON I.item_class_id = IC.item_class_id
+                LEFT JOIN item_skill S
+                    ON I.skill_id = S.skill_id
+                LEFT JOIN attribute SAT
+                    ON S.effect_target_attribute_id = SAT.attribute_id
+                LEFT JOIN item_skill SA
+                    ON I.skill_axe_id = SA.skill_id
+                LEFT JOIN attribute SAAT
+                    ON SA.effect_target_attribute_id = SAAT.attribute_id
+                LEFT JOIN item_skill SS
+                    ON I.skill_sword_id = SS.skill_id
+                LEFT JOIN attribute SSAT
+                    ON SS.effect_target_attribute_id = SSAT.attribute_id
+                LEFT JOIN item_skill SD
+                    ON I.skill_dagger_id = SD.skill_id
+                LEFT JOIN attribute SDAT
+                    ON SD.effect_target_attribute_id = SDAT.attribute_id
                 LEFT JOIN item_attribute IA
                     ON I.item_id = IA.item_id
                 LEFT JOIN attribute A
@@ -369,6 +477,70 @@ class ItemModel extends Model
                 $item['skill_axe_en'] = $result['skill_axe_en'];
                 $item['skill_sword_en'] = $result['skill_sword_en'];
                 $item['skill_dagger_en'] = $result['skill_dagger_en'];
+                if ($result['skill_id'] === null) {
+                    $item['skill'] = null;
+                } else {
+                    $item['skill'] = array();
+                    $item['skill']['id'] = $result['skill_id'];
+                    $item['skill']['name'] = $result['skill_name'];
+                    $item['skill']['trigger_type'] = $result['skill_trigger_type'];
+                    $item['skill']['kill_trigger_type'] = $result['skill_kill_trigger_type'];
+                    $item['skill']['activation_rate'] = $result['skill_activation_rate'];
+                    $item['skill']['trigger_charge'] = $result['skill_trigger_charge'];
+                    $item['skill']['effect_type'] = $result['skill_effect_type'];
+                    $item['skill']['effect_target_attribute'] = $result['skill_effect_target_attribute'];
+                    $item['skill']['effect_amount'] = $result['skill_effect_amount'];
+                    $item['skill']['effect_duration'] = $result['skill_effect_duration'];
+                    $item['skill']['sort_key'] = $result['skill_sort_key'];
+                }
+                if ($result['skill_axe_id'] === null) {
+                    $item['skill_axe'] = null;
+                } else {
+                    $item['skill_axe'] = array();
+                    $item['skill_axe']['id'] = $result['skill_axe_id'];
+                    $item['skill_axe']['name'] = $result['skill_axe_name'];
+                    $item['skill_axe']['trigger_type'] = $result['skill_axe_trigger_type'];
+                    $item['skill_axe']['kill_trigger_type'] = $result['skill_axe_kill_trigger_type'];
+                    $item['skill_axe']['activation_rate'] = $result['skill_axe_activation_rate'];
+                    $item['skill_axe']['trigger_charge'] = $result['skill_axe_trigger_charge'];
+                    $item['skill_axe']['effect_type'] = $result['skill_axe_effect_type'];
+                    $item['skill_axe']['effect_target_attribute'] = $result['skill_axe_effect_target_attribute'];
+                    $item['skill_axe']['effect_amount'] = $result['skill_axe_effect_amount'];
+                    $item['skill_axe']['effect_duration'] = $result['skill_axe_effect_duration'];
+                    $item['skill_axe']['sort_key'] = $result['skill_axe_sort_key'];
+                }
+                if ($result['skill_sword_id'] === null) {
+                    $item['skill_sword'] = null;
+                } else {
+                    $item['skill_sword'] = array();
+                    $item['skill_sword']['id'] = $result['skill_sword_id'];
+                    $item['skill_sword']['name'] = $result['skill_sword_name'];
+                    $item['skill_sword']['trigger_type'] = $result['skill_sword_trigger_type'];
+                    $item['skill_sword']['kill_trigger_type'] = $result['skill_sword_kill_trigger_type'];
+                    $item['skill_sword']['activation_rate'] = $result['skill_sword_activation_rate'];
+                    $item['skill_sword']['trigger_charge'] = $result['skill_sword_trigger_charge'];
+                    $item['skill_sword']['effect_type'] = $result['skill_sword_effect_type'];
+                    $item['skill_sword']['effect_target_attribute'] = $result['skill_sword_effect_target_attribute'];
+                    $item['skill_sword']['effect_amount'] = $result['skill_sword_effect_amount'];
+                    $item['skill_sword']['effect_duration'] = $result['skill_sword_effect_duration'];
+                    $item['skill_sword']['sort_key'] = $result['skill_sword_sort_key'];
+                }
+                if ($result['skill_dagger_id'] === null) {
+                    $item['skill_dagger'] = null;
+                } else {
+                    $item['skill_dagger'] = array();
+                    $item['skill_dagger']['id'] = $result['skill_dagger_id'];
+                    $item['skill_dagger']['name'] = $result['skill_dagger_name'];
+                    $item['skill_dagger']['trigger_type'] = $result['skill_dagger_trigger_type'];
+                    $item['skill_dagger']['kill_trigger_type'] = $result['skill_dagger_kill_trigger_type'];
+                    $item['skill_dagger']['activation_rate'] = $result['skill_dagger_activation_rate'];
+                    $item['skill_dagger']['trigger_charge'] = $result['skill_dagger_trigger_charge'];
+                    $item['skill_dagger']['effect_type'] = $result['skill_dagger_effect_type'];
+                    $item['skill_dagger']['effect_target_attribute'] = $result['skill_dagger_effect_target_attribute'];
+                    $item['skill_dagger']['effect_amount'] = $result['skill_dagger_effect_amount'];
+                    $item['skill_dagger']['effect_duration'] = $result['skill_dagger_effect_duration'];
+                    $item['skill_dagger']['sort_key'] = $result['skill_dagger_sort_key'];
+                }
                 $item['comment_en'] = $result['comment_en'];
                 $item['comment_ja'] = $result['comment_ja'];
                 $item['sort_key'] = $result['sort_key'];

--- a/templates/header.phtml
+++ b/templates/header.phtml
@@ -21,7 +21,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-  <link rel="stylesheet" href="/css/main.css?id=00053">
+  <link rel="stylesheet" href="/css/main.css?id=00071">
   <link rel="stylesheet" href="/lib/photoswipe/photoswipe.css">
   <link rel="stylesheet" href="/lib/photoswipe/default-skin/default-skin.css">
   <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -203,54 +203,54 @@
           </tr>
           <tr>
             <td colspan="2">Attack Damage</td>
-            <td class="text-right"><span class="attr-minad">0</span>～<span class="attr-maxad">0</span></td>
+            <td class="text-right attr-value"><span class="attr-minad">0</span>～<span class="attr-maxad">0</span></td>
           </tr>
           <tr>
             <td colspan="2">Attack Speed</td>
-            <td class="text-right attr-as">0</td>
+            <td class="text-right attr-value attr-as">0</td>
           </tr>
           <tr>
             <td colspan="2">Attack Range</td>
-            <td class="text-right attr-ar">0</td>
+            <td class="text-right attr-value attr-ar">0</td>
           </tr>
           <tr>
             <td colspan="2">Strength</td>
-            <td class="text-right attr-str">0</td>
+            <td class="text-right attr-value attr-str">0</td>
           </tr>
           <tr>
             <td colspan="2">Defense</td>
-            <td class="text-right attr-def">0</td>
+            <td class="text-right attr-value attr-def">0</td>
           </tr>
           <tr>
             <td colspan="2">Dexteriry</td>
-            <td class="text-right attr-dex">0</td>
+            <td class="text-right attr-value attr-dex">0</td>
           </tr>
           <tr>
             <td colspan="2">Vitality</td>
-            <td class="text-right attr-vit">0</td>
+            <td class="text-right attr-value attr-vit">0</td>
           </tr>
           <tr>
             <td colspan="2">Walk Speed</td>
-            <td class="text-right attr-ws">0</td>
+            <td class="text-right attr-value attr-ws">0</td>
           </tr>
           <tr>
             <td colspan="2">Special Attack</td>
-            <td class="text-right">
+            <td class="text-right attr-value">
               <span class="sa-normal"><span class="attr-sa">30</span>&nbsp;sec</span>
               <span class="sa-nodelay d-none">No Delay</span>
             </td>
           </tr>
           <tr>
             <td colspan="2">Vitality on Hit</td>
-            <td class="text-right"><span class="attr-voh">0</span>%</td>
+            <td class="text-right attr-value"><span class="attr-voh">0</span>%</td>
           </tr>
           <tr>
             <td colspan="2">Damage Reflection</td>
-            <td class="text-right"><span class="attr-dr">0</span>%</td>
+            <td class="text-right attr-value"><span class="attr-dr">0</span>%</td>
           </tr>
           <tr>
             <td colspan="2">XP Gain</td>
-            <td class="text-right">+<span class="attr-xpg">0</span>%</td>
+            <td class="text-right attr-value">+<span class="attr-xpg">0</span>%</td>
           </tr>
           <tr>
             <td colspan="3">

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -219,7 +219,7 @@
           </tr>
           <tr>
             <td colspan="2">Defense</td>
-            <td class="text-right attr-value attr-def">0</td>
+            <td class="text-right attr-value"><span class="attr-def">0</span><span class="item-skill skill-reduce-label d-none">&nbsp;&#040;+<span class="skill-reduce">0</span>&#041;</span></td>
           </tr>
           <tr>
             <td colspan="2">Dexteriry</td>


### PR DESCRIPTION
# 新機能追加 : パッシブスキル反映

- DBにパッシブスキルの詳細情報のテーブルを追加
- パッシブスキルに種類ごとの順序になるようソート順を設定
- パッシブスキルのスタッツ補正を計算に含める機能を追加

# 表示項目追加

- シミュレータのスキル一覧でチャージ発動型のスキルを表示する際にスタッツ補正反映用のチェックボックスを追加
- Defの表示欄にダメージ軽減スキルの効果量表示欄を追加

# 仕様変更

- シミュレータのスキル一覧で表示される順序を種類ごとの順序に変更
- シミュレータのアイテム検索でスキルを種類毎にソートするよう変更
- アイテム検索でスキル順にソートした場合、昇順降順どちらの場合もスキルのないアイテムが下になるよう変更