### PR TITLE
クリーチャーデータに絞り込み機能を追加

### DIFF
--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -1,6 +1,65 @@
 $(function () {
 
-  const allCreatures = $.parseJSON($("#init-items").html());
+  const allCreatures = $.parseJSON($("#init-creatures").html());
+  let creatureList = allCreatures;
+
+  const showCreatureList = function () {
+    $.LoadingOverlay("show", {
+      background: "rgba(0, 0, 0, 0.5)",
+      imageColor: "#787878",
+    });
+    const tbody = $('#creature-list > tbody');
+    tbody.children('tr').remove();
+    creatureList.forEach((creature, index) => {
+      if (index % 10 === 0) {
+        tbody.append($($('#list-label-row').html()));
+      }
+      const row = $($('#list-data-row').html());
+      row.find('.selectable')
+        .attr('id', 'creature-' + creature['creature_id'])
+        .data('creatureid', creature['creature_id'])
+        .attr('tabindex', creature['sort_key']);
+      const imageName = creature['image_name'] == null
+        ? 'creature_noimg.png'
+        : creature['image_name'];
+      row.find('.item-icon')
+        .attr('src', '/img/creature/' + imageName)
+        .attr('alt', creature['name_en']);
+      if (!creature['boss']) {
+        row.find('.boss').removeClass('boss');
+      }
+      row.find('.name-ja').text(creature['name_ja']);
+      row.find('.name-en').text(creature['name_en']);
+      row.find('.min-ad').text(creature['min_ad']);
+      row.find('.max-ad').text(creature['max_ad']);
+      row.find('.as').text(creature['as']);
+      row.find('.def').text(creature['def']);
+      row.find('.dex').text(creature['dex']);
+      row.find('.vit').text(creature['vit']);
+      row.find('.voh').text(creature['voh']);
+      row.find('.dr').text(creature['dr']);
+      tbody.append(row);
+    });
+    addSelectRowEvent();
+    $.LoadingOverlay("hide", true);
+  }
+
+  const filterCreatures = function () {
+    const floorId = $('#select-floor').val();
+    const isTBOnly = $('#check-tb').prop('checked');
+    creatureList = allCreatures;
+    console.log(floorId);
+    console.log(isTBOnly);
+    if (floorId) {
+      creatureList = creatureList.filter(
+        creature => creature['floors'] && creature['floors'].some(floor => floor['floor_id'] == floorId));
+    }
+    if (isTBOnly) {
+      creatureList = creatureList.filter(creature => creature['tb'] == 1);
+    }
+    console.log(creatureList);
+    showCreatureList();
+  }
 
   const setPhaseBoost = function (baseTagId, boostVal, level, isPercentage) {
     const base = $(baseTagId);
@@ -48,130 +107,141 @@ $(function () {
     autoTransition = false;
   });
 
-  $("td.selectable").on('click', function () {
-    const at = autoTransition;
-    autoTransition = false;
-    const creatureId = $(this).data('creatureid');
-    $.ajax({
-      url: '/creatures/detail/' + creatureId,
-      type: 'GET',
-    }).done(data => {
-      const creature = data.creature;
-      const imgName = creature.image_name ?
-        creature.image_name : 'creature_noimg.png';
-      const as = creature.as ? creature.as == 0 ? '-' : creature.as : '?';
-      $("#detail-image").attr('src', '/img/creature/' + imgName);
-      $("#detail-name-ja").text(creature.name_ja);
-      $("#detail-name-en").text(creature.name_en);
-      $("#detail-min-ad").text(creature.min_ad ? creature.min_ad : '?')
-        .data("base-val", creature.min_ad);
-      $("#detail-max-ad").text(creature.max_ad ? creature.max_ad : '?')
-        .data("base-val", creature.max_ad);
-      $("#detail-as").text(as)
-        .data("base-val", creature.as);
-      $("#detail-def").text(creature.def ? creature.def : '?')
-        .data("base-val", creature.def);
-      $("#detail-dex").text(creature.dex ? creature.dex : '?')
-        .data("base-val", creature.dex);
-      $("#detail-vit").text(creature.vit ? creature.vit : '?')
-        .data("base-val", creature.vit);
-      $("#detail-ws").text(creature.ws ? creature.ws : '?')
-        .data("base-val", creature.ws);
-      $("#detail-voh").text((creature.voh ? creature.voh : '?') + '%')
-        .data("base-val", creature.voh);
-      $("#detail-dr").text((creature.dr ? creature.dr : '?') + '%')
-        .data("base-val", creature.dr);
-      $("#detail-xp").text(creature.xp ? creature.xp : '?')
-        .data("base-val", creature.xp);
-      $("#tb-ad").text(creature.tb_ad ? creature.tb_ad + '%' : '-')
-        .data("val", creature.tb_ad);
-      $("#tb-as").text(creature.tb_as ? creature.tb_as + '%' : '-')
-        .data("val", creature.tb_as);
-      $("#tb-def").text(creature.tb_def ? creature.tb_def + '%' : '-')
-        .data("val", creature.tb_def);
-      $("#tb-dex").text(creature.tb_dex ? creature.tb_dex + '%' : '-')
-        .data("val", creature.tb_dex);
-      $("#tb-vit").text(creature.tb_vit ? creature.tb_vit + '%' : '-')
-        .data("val", creature.tb_vit);
-      $("#tb-ws").text(creature.tb_ws ? creature.tb_ws + '%' : '-')
-        .data("val", creature.tb_ws);
-      $("#tb-voh").text(creature.tb_voh ? creature.tb_voh + '%' : '-')
-        .data("val", creature.tb_voh);
-      $("#tb-dr").text(creature.tb_dr ? creature.tb_dr + '%' : '-')
-        .data("val", creature.tb_dr);
-      $("#tb-xp").text(creature.tb_xp ? creature.tb_xp + '%' : '-')
-        .data("val", creature.tb_xp);
-      if (creature.boss == 1) {
-        $("#detail-name").addClass("boss");
-      } else {
-        $("#detail-name").removeClass("boss");
-      }
-      if (creature.tb == 1) {
-        $("#detail-tb-boosts,#detail-row-tb-phase").removeClass("d-none");
-      } else {
-        $("#detail-tb-boosts,#detail-row-tb-phase").addClass("d-none");
-      }
-
-      const saTbody = $("#detail-sa");
-      saTbody.children('tr').remove();
-      if (creature.special_attacks.length == 0) {
-        saTbody.append($("<tr>").append($("<td>").addClass("pl-2").text("None")));
-      }
-      creature.special_attacks.forEach(sa => {
-        const row = $($("#modal-sa-row").html());
-        row.find(".sa-name").text(sa.name);
-        row.find(".sa-note").attr('title', sa.note);
-        saTbody.append(row);
-      });
-      saTbody.find("a.sa-note").tooltip();
-
-      const itemTbody = $("#detail-items");
-      itemTbody.children('tr').remove();
-      if (creature.items.length == 0) {
-        itemTbody.append($("<tr>").append($("<td>").addClass("pl-2").text("None")));
-      }
-      creature.items.forEach(item => {
-        const row = $($("#modal-item-row").html());
-        const link = '/items/' + item.item_class.toLowerCase() + '/'
-          + (item.rarity == 'common' ? item.base_item_id : 'rare') + '/' + item.item_id;
-        const img = item.image_name ? item.image_name : 'item_noimg.png';
-        row.find('a').attr('href', link).addClass(item.rarity);
-        row.find('img.item-icon')
-          .attr('src', '/img/item/' + img).attr('alt', item.name_en);
-        row.find('span').text(item.name_en);
-        if (item.class_flactuable == 0) {
-          row.find('img.class-icon').remove();
+  const addSelectRowEvent = function () {
+    $("td.selectable").on('click', function () {
+      const at = autoTransition;
+      autoTransition = false;
+      const creatureId = $(this).data('creatureid');
+      $.ajax({
+        url: '/creatures/detail/' + creatureId,
+        type: 'GET',
+      }).done(data => {
+        const creature = data.creature;
+        const imgName = creature.image_name ?
+          creature.image_name : 'creature_noimg.png';
+        const as = creature.as ? creature.as == 0 ? '-' : creature.as : '?';
+        $("#detail-image").attr('src', '/img/creature/' + imgName);
+        $("#detail-name-ja").text(creature.name_ja);
+        $("#detail-name-en").text(creature.name_en);
+        $("#detail-min-ad").text(creature.min_ad ? creature.min_ad : '?')
+          .data("base-val", creature.min_ad);
+        $("#detail-max-ad").text(creature.max_ad ? creature.max_ad : '?')
+          .data("base-val", creature.max_ad);
+        $("#detail-as").text(as)
+          .data("base-val", creature.as);
+        $("#detail-def").text(creature.def ? creature.def : '?')
+          .data("base-val", creature.def);
+        $("#detail-dex").text(creature.dex ? creature.dex : '?')
+          .data("base-val", creature.dex);
+        $("#detail-vit").text(creature.vit ? creature.vit : '?')
+          .data("base-val", creature.vit);
+        $("#detail-ws").text(creature.ws ? creature.ws : '?')
+          .data("base-val", creature.ws);
+        $("#detail-voh").text((creature.voh ? creature.voh : '?') + '%')
+          .data("base-val", creature.voh);
+        $("#detail-dr").text((creature.dr ? creature.dr : '?') + '%')
+          .data("base-val", creature.dr);
+        $("#detail-xp").text(creature.xp ? creature.xp : '?')
+          .data("base-val", creature.xp);
+        $("#tb-ad").text(creature.tb_ad ? creature.tb_ad + '%' : '-')
+          .data("val", creature.tb_ad);
+        $("#tb-as").text(creature.tb_as ? creature.tb_as + '%' : '-')
+          .data("val", creature.tb_as);
+        $("#tb-def").text(creature.tb_def ? creature.tb_def + '%' : '-')
+          .data("val", creature.tb_def);
+        $("#tb-dex").text(creature.tb_dex ? creature.tb_dex + '%' : '-')
+          .data("val", creature.tb_dex);
+        $("#tb-vit").text(creature.tb_vit ? creature.tb_vit + '%' : '-')
+          .data("val", creature.tb_vit);
+        $("#tb-ws").text(creature.tb_ws ? creature.tb_ws + '%' : '-')
+          .data("val", creature.tb_ws);
+        $("#tb-voh").text(creature.tb_voh ? creature.tb_voh + '%' : '-')
+          .data("val", creature.tb_voh);
+        $("#tb-dr").text(creature.tb_dr ? creature.tb_dr + '%' : '-')
+          .data("val", creature.tb_dr);
+        $("#tb-xp").text(creature.tb_xp ? creature.tb_xp + '%' : '-')
+          .data("val", creature.tb_xp);
+        if (creature.boss == 1) {
+          $("#detail-name").addClass("boss");
         } else {
-          row.find('img.class-icon').attr('src', '/img/common/' + item.item_class.toLowerCase() + '.png');
+          $("#detail-name").removeClass("boss");
         }
-        itemTbody.append(row);
-      });
-
-      const floors = $("#detail-floors");
-      floors.children('li').remove();
-      if (creature.floors.length == 0) {
-        floors.append($("<li>").addClass("list-inline-item").text("None"));
-      }
-      creature.floors.forEach(floor => {
-        const li = $($("#modal-floor-li").html());
-        li.find(".floor-name").text(floor.short_name).attr('href', "/floors/" + floor.floor_id);
-        if (floor.note) {
-          li.find(".floor-note").attr('title', floor.note);
+        if (creature.tb == 1) {
+          $("#detail-tb-boosts,#detail-row-tb-phase").removeClass("d-none");
         } else {
-          li.find(".floor-note").remove();
+          $("#detail-tb-boosts,#detail-row-tb-phase").addClass("d-none");
         }
-        floors.append(li);
+
+        const saTbody = $("#detail-sa");
+        saTbody.children('tr').remove();
+        if (creature.special_attacks.length == 0) {
+          saTbody.append($("<tr>").append($("<td>").addClass("pl-2").text("None")));
+        }
+        creature.special_attacks.forEach(sa => {
+          const row = $($("#modal-sa-row").html());
+          row.find(".sa-name").text(sa.name);
+          row.find(".sa-note").attr('title', sa.note);
+          saTbody.append(row);
+        });
+        saTbody.find("a.sa-note").tooltip();
+
+        const itemTbody = $("#detail-items");
+        itemTbody.children('tr').remove();
+        if (creature.items.length == 0) {
+          itemTbody.append($("<tr>").append($("<td>").addClass("pl-2").text("None")));
+        }
+        creature.items.forEach(item => {
+          const row = $($("#modal-item-row").html());
+          const link = '/items/' + item.item_class.toLowerCase() + '/'
+            + (item.rarity == 'common' ? item.base_item_id : 'rare') + '/' + item.item_id;
+          const img = item.image_name ? item.image_name : 'item_noimg.png';
+          row.find('a').attr('href', link).addClass(item.rarity);
+          row.find('img.item-icon')
+            .attr('src', '/img/item/' + img).attr('alt', item.name_en);
+          row.find('span').text(item.name_en);
+          if (item.class_flactuable == 0) {
+            row.find('img.class-icon').remove();
+          } else {
+            row.find('img.class-icon').attr('src', '/img/common/' + item.item_class.toLowerCase() + '.png');
+          }
+          itemTbody.append(row);
+        });
+
+        const floors = $("#detail-floors");
+        floors.children('li').remove();
+        if (creature.floors.length == 0) {
+          floors.append($("<li>").addClass("list-inline-item").text("None"));
+        }
+        creature.floors.forEach(floor => {
+          const li = $($("#modal-floor-li").html());
+          li.find(".floor-name").text(floor.short_name).attr('href', "/floors/" + floor.floor_id);
+          if (floor.note) {
+            li.find(".floor-note").attr('title', floor.note);
+          } else {
+            li.find(".floor-note").remove();
+          }
+          floors.append(li);
+        });
+        floors.find("a.floor-note").tooltip();
+
+        if (!at && location.pathname.split('/').length != 3) {
+          history.pushState(null, null, '/creatures/' + creatureId);
+        }
+
+        $("select.tb-phase").trigger('change');
+
+        $("#modal-creature").modal("show");
       });
-      floors.find("a.floor-note").tooltip();
-
-      if (!at && location.pathname.split('/').length != 3) {
-        history.pushState(null, null, '/creatures/' + creatureId);
-      }
-
-      $("select.tb-phase").trigger('change');
-
-      $("#modal-creature").modal("show");
     });
+  }
+
+  addSelectRowEvent();
+
+  $('#select-floor').on('change', function () {
+    filterCreatures();
+  });
+  $('#check-tb').on('change', function () {
+    filterCreatures();
   });
 
   $("select.tb-phase").on('change', function () {

--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -1,5 +1,7 @@
 $(function () {
 
+  const allCreatures = $.parseJSON($("#init-items").html());
+
   const setPhaseBoost = function (baseTagId, boostVal, level, isPercentage) {
     const base = $(baseTagId);
     const baseTd1 = $("td" + baseTagId);

--- a/src/classes/controller/CreaturesController.php
+++ b/src/classes/controller/CreaturesController.php
@@ -7,6 +7,7 @@ use Slim\Exception\NotFoundException;
 use Slim\Http\Request;
 use Slim\Http\Response;
 use Model\CreatureModel;
+use Model\FloorModel;
 
 /**
  * クリーチャーデータ コントローラ.
@@ -17,12 +18,13 @@ class CreaturesController extends Controller
     public function index(Request $request, Response $response, array $args)
     {
         $this->title = 'クリーチャーデータ';
-        $this->scripts[] = '/js/creature.js?id=00066';
+        $this->scripts[] = '/js/creature.js?id=00072';
 
         try {
             $this->db->beginTransaction();
 
             $creature = new CreatureModel($this->db, $this->logger);
+            $floor = new FloorModel($this->db, $this->logger);
 
             if (array_key_exists('creatureId', $args)) {
                 $detail = $creature->getCreatureDetailById($args['creatureId']);
@@ -32,6 +34,7 @@ class CreaturesController extends Controller
             $args = [
                 'header' => $this->getHeaderInfo(),
                 'creatures' => $creature->getCreatureStutsList(),
+                'floorIndex' => $floor->getFloorIndex(),
                 'footer' => $this->getFooterInfo()
             ];
 

--- a/src/classes/model/CreatureModel.php
+++ b/src/classes/model/CreatureModel.php
@@ -33,6 +33,7 @@ class CreatureModel extends Model
                 , c.tb_ws
                 , c.tb_voh
                 , c.tb_dr
+                , c.sort_key
                 , fc.floor_id
                 , fc.event_id
             FROM

--- a/src/classes/model/CreatureModel.php
+++ b/src/classes/model/CreatureModel.php
@@ -11,45 +11,85 @@ class CreatureModel extends Model
     {
         $sql = <<<SQL
             SELECT
-                creature_id
-                , boss
-                , name_en
-                , name_ja
-                , image_name
-                , min_ad
-                , max_ad
-                , `as`
-                , def
-                , dex
-                , vit
-                , voh
-                , dr
+                c.creature_id
+                , c.boss
+                , c.name_en
+                , c.name_ja
+                , c.image_name
+                , c.min_ad
+                , c.max_ad
+                , c.`as`
+                , c.def
+                , c.dex
+                , c.vit
+                , c.voh
+                , c.dr
+                , c.tb
+                , c.tb_ad
+                , c.tb_as
+                , c.tb_def
+                , c.tb_dex
+                , c.tb_vit
+                , c.tb_ws
+                , c.tb_voh
+                , c.tb_dr
+                , fc.floor_id
+                , fc.event_id
             FROM
-                creature
+                creature c
+                INNER JOIN floor_creature fc
+                    ON fc.creature_id = c.creature_id
+                INNER JOIN floor f
+                    ON f.floor_id = fc.floor_id
             ORDER BY
-                boss
-                , sort_key
+                c.boss
+                , c.sort_key
+                , f.sort_key
+                , fc.event_id
             SQL;
         $this->logger->debug($sql);
         $stmt = $this->db->prepare($sql);
         $stmt->execute();
         $creatures = [];
+        $prevCreatureId = 0;
         while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $creatures[] = [
-                'creature_id' => $result['creature_id'],
-                'boss' => $result['boss'] == 1,
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'image_name' => $result['image_name'],
-                'min_ad' => $this->getFormattedStats($result['min_ad'], false),
-                'max_ad' => $this->getFormattedStats($result['max_ad'], false),
-                'as' => $this->getFormattedStats($result['as'], true),
-                'def' => $this->getFormattedStats($result['def'], false),
-                'dex' => $this->getFormattedStats($result['dex'], false),
-                'vit' => $this->getFormattedStats($result['vit'], false),
-                'voh' => $this->getFormattedStats($result['voh'], false),
-                'dr' => $this->getFormattedStats($result['dr'], false)
-            ];
+            if ($result['creature_id'] != $prevCreatureId) {
+                $prevCreatureId = $result['creature_id'];
+                $creatures[] = [
+                    'creature_id' => $result['creature_id'],
+                    'boss' => $result['boss'] == 1,
+                    'name_en' => $result['name_en'],
+                    'name_ja' => $result['name_ja'],
+                    'image_name' => $result['image_name'],
+                    'min_ad' => $this->getFormattedStats($result['min_ad'], false),
+                    'max_ad' => $this->getFormattedStats($result['max_ad'], false),
+                    'as' => $this->getFormattedStats($result['as'], true),
+                    'def' => $this->getFormattedStats($result['def'], false),
+                    'dex' => $this->getFormattedStats($result['dex'], false),
+                    'vit' => $this->getFormattedStats($result['vit'], false),
+                    'voh' => $this->getFormattedStats($result['voh'], false),
+                    'dr' => $this->getFormattedStats($result['dr'], false),
+                    'tb' => $result['tb'],
+                    'tb_ad' => $result['tb_ad'],
+                    'tb_as' => $result['tb_as'],
+                    'tb_def' => $result['tb_def'],
+                    'tb_dex' => $result['tb_dex'],
+                    'tb_vit' => $result['tb_vit'],
+                    'tb_voh' => $result['tb_voh'],
+                    'tb_dr' => $result['tb_dr'],
+                    'floors' => [
+                        [
+                            'floor_id' => $result['floor_id'],
+                            'event_id' => $result['event_id']
+                        ]
+                    ]
+                ];
+            } else {
+                $creatures[count($creatures) - 1]['floors'][] = [
+                    'floor_id' => $result['floor_id'],
+                    'event_id' => $result['event_id']
+                ];
+            }
         }
         return $creatures;
     }
@@ -139,11 +179,11 @@ class CreatureModel extends Model
                 , SA.cooldown
                 , SA.note
             FROM
-                creature_special_attack CSA 
-                INNER JOIN special_attack SA 
-                ON CSA.special_attack_id = SA.special_attack_id 
+                creature_special_attack CSA
+                INNER JOIN special_attack SA
+                ON CSA.special_attack_id = SA.special_attack_id
             WHERE
-                CSA.creature_id = :id 
+                CSA.creature_id = :id
             ORDER BY
                 SA.special_attack_id
             SQL;
@@ -173,15 +213,15 @@ class CreatureModel extends Model
                 , I.class_flactuable
                 , I.name_en
                 , I.rarity
-                , I.image_name 
+                , I.image_name
             FROM
-                creature_drop_item CDI 
-                INNER JOIN item I 
-                    ON CDI.item_id = I.item_id 
-                INNER JOIN item_class IC 
-                    ON I.item_class_id = IC.item_class_id 
+                creature_drop_item CDI
+                INNER JOIN item I
+                    ON CDI.item_id = I.item_id
+                INNER JOIN item_class IC
+                    ON I.item_class_id = IC.item_class_id
             WHERE
-                CDI.creature_id = :id 
+                CDI.creature_id = :id
             ORDER BY
                 I.sort_key
                 , I.item_id
@@ -212,15 +252,15 @@ class CreatureModel extends Model
                 F.floor_id
                 , F.short_name
                 , F.name_en
-                , E.note 
+                , E.note
             FROM
-                floor_creature FC 
-                INNER JOIN floor F 
-                    ON FC.floor_id = F.floor_id 
-                LEFT JOIN creature_pop_event E 
-                    ON FC.event_id = E.event_id 
+                floor_creature FC
+                INNER JOIN floor F
+                    ON FC.floor_id = F.floor_id
+                LEFT JOIN creature_pop_event E
+                    ON FC.event_id = E.event_id
             WHERE
-                FC.creature_id = :id 
+                FC.creature_id = :id
             ORDER BY
                 F.sort_key
                 , E.event_id

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -204,6 +204,63 @@
 <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
 <table class="table-dark table-striped table-hover w-100 small" id="creature-list">
   <tbody>
+    <template id="list-label-row">
+      <tr>
+        <td style="padding-left: 33px;">
+          <div class="d-table w-100 table-item-attrs">
+            <div class="d-table-row rare">
+              <div class="d-table-cell border border-black text-center w-16">AD</div>
+              <div class="d-table-cell border border-black text-center w-14">AS</div>
+              <div class="d-table-cell border border-black text-center w-14">Def</div>
+              <div class="d-table-cell border border-black text-center w-14">Dex</div>
+              <div class="d-table-cell border border-black text-center w-14">Vit</div>
+              <div class="d-table-cell border border-black text-center w-14">VoH</div>
+              <div class="d-table-cell border border-black text-center w-14">DR</div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </template>
+    <template id="list-data-row">
+      <tr>
+        <td class="selectable" id="creature-0" data-creatureid="0" tabindex="0">
+          <div class="d-table-cell align-middle" style="width: 32px;">
+            <img class="item-icon" src="/img/creature/creature_noimg.png" alt="" />
+          </div>
+          <div class="d-table-cell w-100 align-top">
+            <div class="pl-1 boss">
+              <div class="name-ja"></div>
+              <div class="name-en"></div>
+            </div>
+            <div class="d-table w-100 table-item-attrs">
+              <div class="d-table-row">
+                <div class="d-table-cell border border-black text-right w-16">
+                  &nbsp;<span class="min-ad"></span>~<span class="max-ad"></span>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <span class="as"></span>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <span class="def"></span>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <span class="dex"></span>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <span class="vit"></span>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <span class="voh"></span>
+                </div>
+                <div class="d-table-cell border border-black text-right w-14">
+                  <span class="dr"></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </template>
     <?php if (empty($creatures)) : ?>
       <tr>
         <td>No Data</td>

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -1,4 +1,7 @@
 <?= $this->fetch('header.phtml', ['header' => $header]) ?>
+<script id="init-creatures" type="application/json">
+  <?= json_encode($creatures) ?>
+</script>
 <div class="modal fade" id="modal-creature" tabindex="-1" role="dialog" aria-labelledby="modal-creaturesTitle" aria-hidden="true">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content bg-darkgreen">

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -33,7 +33,7 @@
               <tr id="detail-row-tb-phase">
                 <td colspan="2">TB Phase</td>
                 <td class="text-right" colspan="3">
-                  <select class="form-control tb-phase p-0 h-auto">
+                  <select id="tb-phase-detail" class="form-control tb-phase p-0 h-auto">
                     <?php foreach (range(0, 63) as $phaseLevel) : ?>
                       <option value="<?= $phaseLevel ?>">
                         #<?= $phaseLevel * 4 + 1 ?>&nbsp;～&nbsp;#<?= $phaseLevel * 4 + 4 ?>
@@ -202,6 +202,19 @@
 </div>
 <h2>Creatures</h2>
 <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
+<div class="d-inline-block">
+  <select id="select-floor" class="form-control p-0 h-auto">
+    <option value="">All Floors</option>
+    <?php foreach ($floorIndex as $groupIndex => $floorGroup) : ?>
+      <?php foreach ($floorGroup['floors'] as $index => $floor) : ?>
+        <option value="<?= $floor['floor_id'] ?>">[<?= $floor['short_name'] ?>]&nbsp;<?= $floor['name_en'] ?></option>
+      <?php endforeach ?>
+    <?php endforeach ?>
+  </select>
+</div>
+<div class="d-inline-block pl-4">
+  <input type="checkbox" id="check-tb" class="form-check-input" value="true" /><label for="check-tb">TB Creature</label>
+</div>
 <table class="table-dark table-striped table-hover w-100 small" id="creature-list">
   <tbody>
     <template id="list-label-row">
@@ -285,7 +298,7 @@
         </tr>
       <?php endif; ?>
       <tr>
-        <td class="selectable" id="creature-<?= $creature['creature_id'] ?>" data-creatureid="<?= $creature['creature_id'] ?>" tabindex="<?= $creature['creature_id'] ?>">
+        <td class="selectable" id="creature-<?= $creature['creature_id'] ?>" data-creatureid="<?= $creature['creature_id'] ?>" tabindex="<?= $creature['sort_key'] ?>">
           <div class="d-table-cell align-middle" style="width: 32px;">
             <img class="item-icon" src="/img/creature/<?= $creature['image_name'] == null ? 'creature_noimg.png' : $creature['image_name'] ?>" alt="<?= $creature['name_en'] ?>" />
           </div>


### PR DESCRIPTION
# 新機能追加：クリーチャー一覧絞り込み

- フロアもしくは結界地出現のみの条件で一覧を絞り込むことができる
- フロアを選択もしくは結界地出現のチェックを変更すると一覧を絞り込んで再構築する
- 絞り込みの状態はページ遷移しない限り保持される

# 表示項目追加

- 絞り込み用のフロア選択を追加
  - デフォルトでは全フロアを選択している
- 絞り込み用の結界地出現のみのチェックボックスを追加
  - デフォルトではチェックなし

# 仕様変更

- クリーチャー一覧のtabインデックスをクリーチャーIDからソート順番号に変更