### PR TITLE
広告表示欄の表示設定を設定項目に追加

### DIFF
--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -42,6 +42,8 @@ return function (App $app) {
         $google = [
             'analytics_id' => $settings['analytics_id'],
             'adsense_id' => $settings['adsense_id'],
+            'adsense_unit' => $settings['adsense_unit'],
+            'adsense_enabled' => $settings['adsense_enabled'],
         ];
         return $google;
     };

--- a/src/sample.settings.php
+++ b/src/sample.settings.php
@@ -29,6 +29,7 @@ return [
             'analytics_id' => '',
             'adsense_id' => '',
             'adsense_unit' => '',
+            'adsense_enabled' => true,
         ],
     ],
 ];

--- a/templates/adsense.phtml
+++ b/templates/adsense.phtml
@@ -1,14 +1,16 @@
-<div class="row">
-  <div class="d-none d-md-block col-md-1 col-xl-2"></div>
-  <div class="col-12 col-md-10 col-xl-8 my-2">
-    <?php if (!empty($google['adsense_id'])) : ?>
-      <ins class="adsbygoogle" style="display:block" data-ad-client="<?= $google['adsense_id'] ?>" data-ad-slot="<?= $google['adsense_unit'] ?>" data-ad-format="auto" data-full-width-responsive="true"></ins>
-      <script>
-        (adsbygoogle = window.adsbygoogle || []).push({});
-      </script>
-    <?php else : ?>
-      <div class="bg-info p-5">Ads Test</div>
-    <?php endif; ?>
+<?php if ($google['adsense_enabled']) : ?>
+  <div class="row">
+    <div class="d-none d-md-block col-md-1 col-xl-2"></div>
+    <div class="col-12 col-md-10 col-xl-8 my-2">
+      <?php if (!empty($google['adsense_id'])) : ?>
+        <ins class="adsbygoogle" style="display:block" data-ad-client="<?= $google['adsense_id'] ?>" data-ad-slot="<?= $google['adsense_unit'] ?>" data-ad-format="auto" data-full-width-responsive="true"></ins>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      <?php else : ?>
+        <div class="bg-info p-5">Ads Test</div>
+      <?php endif; ?>
+    </div>
+    <div class="d-none d-md-block col-md-1 col-xl-2"></div>
   </div>
-  <div class="d-none d-md-block col-md-1 col-xl-2"></div>
-</div>
+<?php endif; ?>


### PR DESCRIPTION
# 設定項目の追加 : 広告表示欄の表示設定を追加

- settings.phpのgoogle.adsense_enabledをfalseに設定することで広告表示欄を非表示にできる
  - 広告の表示、非表示に関係なく、表示枠の領域自体を確保しないようにする
- サンプルはtrueとなっている
- 必ずtrueもしくはfalseの値を設定すること