### PR TITLE
クリーチャー一覧で出現フロアを持たないクリーチャーが表示されない不具合を修正

### DIFF
--- a/src/classes/model/CreatureModel.php
+++ b/src/classes/model/CreatureModel.php
@@ -38,9 +38,9 @@ class CreatureModel extends Model
                 , fc.event_id
             FROM
                 creature c
-                INNER JOIN floor_creature fc
+                LEFT JOIN floor_creature fc
                     ON fc.creature_id = c.creature_id
-                INNER JOIN floor f
+                LEFT JOIN floor f
                     ON f.floor_id = fc.floor_id
             ORDER BY
                 c.boss


### PR DESCRIPTION
# 不具合修正 : クリーチャー一覧で出現フロアを持たないクリーチャーが表示されない不具合を修正

- 一覧取得SQLのINNER JOINをLEFT JOINに修正