### PR TITLE
ページタグ機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ tags
 /public/img/common
 /public/favicon.ico
 /templates/privacy/index.phtml
+!/templates/tags
 
 # End of https://www.gitignore.io/api/vim,linux,laravel,composer

--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,5 +1,5 @@
 -- Project Name : Uruluk
--- Date/Time    : 2023/09/03 2:07:11
+-- Date/Time    : 2024/02/20 17:18:34
 -- Author       : candl
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
@@ -387,6 +387,17 @@ alter table `item_skill` add unique `item_skill_IX1` (`name`) ;
 
 alter table `item_skill` add unique `item_skill_IX2` (`sort_key`) ;
 
+-- アイテムタグ
+-- * BackupToTempTable
+drop table if exists `item_tag` cascade;
+
+-- * RestoreFromTempTable
+create table `item_tag` (
+  `item_id` INT not null comment 'アイテムID'
+  , `tag_id` INT not null comment 'タグID'
+  , constraint `item_tag_PKC` primary key (`item_id`,`tag_id`)
+) comment 'アイテムタグ' ;
+
 -- お知らせ
 -- * BackupToTempTable
 drop table if exists `news` cascade;
@@ -505,6 +516,23 @@ create table `special_attack` (
   , `note` TEXT comment '説明'
   , constraint `special_attack_PKC` primary key (`special_attack_id`)
 ) comment 'スペシャルアタック' ;
+
+-- タグ
+-- * BackupToTempTable
+drop table if exists `tag` cascade;
+
+-- * RestoreFromTempTable
+create table `tag` (
+  `tag_id` INT not null AUTO_INCREMENT comment 'タグID'
+  , `tag_url` VARCHAR(32) not null comment 'タグURL'
+  , `tag_name` VARCHAR(100) comment 'タグ名'
+  , `sort_key` VARCHAR(16) not null comment 'ソート順'
+  , constraint `tag_PKC` primary key (`tag_id`)
+) comment 'タグ' ;
+
+alter table `tag` add unique `tag_IX1` (`tag_url`) ;
+
+alter table `tag` add unique `tag_IX2` (`sort_key`) ;
 
 -- Urulukユーザ
 -- * BackupToTempTable

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -191,6 +191,10 @@ a.item-name {
   padding-right: 5px;
 }
 
+a.tag-name.badge {
+  font-size: 85%;
+}
+
 div.tooltip-inner {
   color: #9fd900 !important;
 }

--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -117,6 +117,8 @@ $(function () {
         type: 'GET',
       }).done(data => {
         const creature = data.creature;
+        const items = data.items;
+        const floors = data.floors;
         const imgName = creature.image_name ?
           creature.image_name : 'creature_noimg.png';
         const as = creature.as ? creature.as == 0 ? '-' : creature.as : '?';
@@ -187,10 +189,10 @@ $(function () {
 
         const itemTbody = $("#detail-items");
         itemTbody.children('tr').remove();
-        if (creature.items.length == 0) {
+        if (items.length == 0) {
           itemTbody.append($("<tr>").append($("<td>").addClass("pl-2").text("None")));
         }
-        creature.items.forEach(item => {
+        items.forEach(item => {
           const row = $($("#modal-item-row").html());
           const link = '/items/' + item.item_class.toLowerCase() + '/'
             + (item.rarity == 'common' ? item.base_item_id : 'rare') + '/' + item.item_id;
@@ -207,12 +209,12 @@ $(function () {
           itemTbody.append(row);
         });
 
-        const floors = $("#detail-floors");
-        floors.children('li').remove();
-        if (creature.floors.length == 0) {
-          floors.append($("<li>").addClass("list-inline-item").text("None"));
+        const floorList = $("#detail-floors");
+        floorList.children('li').remove();
+        if (floors.length == 0) {
+          floorList.append($("<li>").addClass("list-inline-item").text("None"));
         }
-        creature.floors.forEach(floor => {
+        floors.forEach(floor => {
           const li = $($("#modal-floor-li").html());
           li.find(".floor-name").text(floor.short_name).attr('href', "/floors/" + floor.floor_id);
           if (floor.note) {
@@ -220,9 +222,9 @@ $(function () {
           } else {
             li.find(".floor-note").remove();
           }
-          floors.append(li);
+          floorList.append(li);
         });
-        floors.find("a.floor-note").tooltip();
+        floorList.find("a.floor-note").tooltip();
 
         if (!at && location.pathname.split('/').length != 3) {
           history.pushState(null, null, '/creatures/' + creatureId);

--- a/public/js/item.js
+++ b/public/js/item.js
@@ -60,18 +60,21 @@ $(function () {
       url: '/items/detail/' + itemId,
       type: 'GET',
     }).done(data => {
-      const item = data.item;
+      const floors = data.floors;
+      const bananaFloors = data.banana;
+      const treasureFloors = data.treasure;
+      const creatures = data.creatures;
       const quests = data.quests;
       const shops = data.shops;
       const tags = data.tags;
 
       $('#detail-floors').children('li.detail-row').remove();
-      if (item.floors.length) {
+      if (floors.length) {
         $('#detail-floor-none').addClass('d-none');
       } else {
         $('#detail-floor-none').removeClass('d-none');
       }
-      item.floors.forEach(floor => {
+      floors.forEach(floor => {
         const row = $($("#modal-floor-row").html());
         row.find(".floor-name").text(floor.short_name)
           .attr('href', '/floors/' + floor.floor_id);
@@ -79,12 +82,12 @@ $(function () {
       });
 
       $('#detail-banana').children('li.detail-row').remove();
-      if (item.banana.length) {
+      if (bananaFloors.length) {
         $('#detail-banana-none').addClass('d-none');
       } else {
         $('#detail-banana-none').removeClass('d-none');
       }
-      item.banana.forEach(floor => {
+      bananaFloors.forEach(floor => {
         const row = $($("#modal-banana-row").html());
         row.find(".floor-name").text(floor.short_name)
           .attr('href', '/floors/' + floor.floor_id);
@@ -92,12 +95,12 @@ $(function () {
       });
 
       $('#detail-treasure').children('li.detail-row').remove();
-      if (item.treasure.length) {
+      if (treasureFloors.length) {
         $('#detail-treasure-none').addClass('d-none');
       } else {
         $('#detail-treasure-none').removeClass('d-none');
       }
-      item.treasure.forEach(floor => {
+      treasureFloors.forEach(floor => {
         const row = $($("#modal-treasure-row").html());
         row.find(".floor-name").text(floor.short_name)
           .attr('href', '/floors/' + floor.floor_id);
@@ -111,12 +114,12 @@ $(function () {
       $('#detail-treasure').find('a.treasure-note').tooltip();
 
       $('#detail-creatures').children('li.detail-row').remove();
-      if (item.creatures.length) {
+      if (creatures.length) {
         $('#detail-creature-none').addClass('d-none');
       } else {
         $('#detail-creature-none').removeClass('d-none');
       }
-      item.creatures.forEach(creature => {
+      creatures.forEach(creature => {
         const row = $($("#modal-creature-row").html());
         const imgName = creature.image_name ?
           creature.image_name : 'creature_noimg.png';

--- a/public/js/item.js
+++ b/public/js/item.js
@@ -63,6 +63,7 @@ $(function () {
       const item = data.item;
       const quests = data.quests;
       const shops = data.shops;
+      const tags = data.tags;
 
       $('#detail-floors').children('li.detail-row').remove();
       if (item.floors.length) {
@@ -203,6 +204,20 @@ $(function () {
             .attr('src', '/img/' + icon.image_path));
         });
         $('#detail-quest-required').append(row);
+      });
+
+      $('#detail-tags').children('li.detail-row').remove();
+      if (tags.length) {
+        $('#detail-tags-none').addClass('d-none');
+      } else {
+        $('#detail-tags-none').removeClass('d-none');
+      }
+      tags.forEach(tag => {
+        const row = $($("#modal-tag-row").html());
+        row.find('.tag-name')
+          .attr('href', '/tags/' + tag.tag_url)
+          .text(tag.tag_name);
+        $('#detail-tags').append(row);
       });
 
       if (!at && location.pathname.split('/').length != 5) {

--- a/src/classes/controller/CreaturesController.php
+++ b/src/classes/controller/CreaturesController.php
@@ -8,6 +8,7 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 use Model\CreatureModel;
 use Model\FloorModel;
+use Model\ItemModel;
 
 /**
  * クリーチャーデータ コントローラ.
@@ -18,7 +19,7 @@ class CreaturesController extends Controller
     public function index(Request $request, Response $response, array $args)
     {
         $this->title = 'クリーチャーデータ';
-        $this->scripts[] = '/js/creature.js?id=00072';
+        $this->scripts[] = '/js/creature.js?id=00075';
 
         try {
             $this->db->beginTransaction();
@@ -50,10 +51,14 @@ class CreaturesController extends Controller
     public function detail(Request $request, Response $response, array $args)
     {
         $creature = new CreatureModel($this->db, $this->logger);
+        $item = new ItemModel($this->db, $this->logger);
+        $floor = new FloorModel($this->db, $this->logger);
         $detail = $creature->getCreatureDetailById($args['creatureId']);
         if ($detail == null) throw new NotFoundException($request, $response);
         $data = [
-            'creature' => $detail
+            'creature' => $detail,
+            'items' => $item->getItemsByCreatureId($args['creatureId']),
+            'floors' => $floor->getFloorsByCreatureId($args['creatureId'])
         ];
 
         return $response->withJson($data);

--- a/src/classes/controller/ItemsController.php
+++ b/src/classes/controller/ItemsController.php
@@ -9,6 +9,7 @@ use Slim\Http\Response;
 use Model\ItemModel;
 use Model\QuestModel;
 use Model\ShopModel;
+use Model\TagModel;
 
 /**
  * アイテムデータ コントローラ.
@@ -42,7 +43,7 @@ class ItemsController extends Controller
     public function rareItem(Request $request, Response $response, array $args)
     {
         $this->title = ucfirst($args['itemClassName']) . ' レアアイテム';
-        $this->scripts[] = '/js/item.js?id=00047';
+        $this->scripts[] = '/js/item.js?id=00075';
 
         try {
             $this->db->beginTransaction();
@@ -107,11 +108,13 @@ class ItemsController extends Controller
         $item = new ItemModel($this->db, $this->logger);
         $quest = new QuestModel($this->db, $this->logger);
         $shop = new ShopModel($this->db, $this->logger);
+        $tag = new TagModel($this->db, $this->logger);
         $detail = $item->getItemDetailById($args['itemId']);
         $data = [
             'item' => $detail,
             'quests' => $quest->getQuestDetailListByItemId($args['itemId']),
-            'shops' => $shop->getShopListByItemId($args['itemId'])
+            'shops' => $shop->getShopListByItemId($args['itemId']),
+            'tags' => $tag->getTagsByItemId($args['itemId'])
         ];
         return $response->withJson($data);
     }

--- a/src/classes/controller/ItemsController.php
+++ b/src/classes/controller/ItemsController.php
@@ -3,6 +3,8 @@
 namespace Controller;
 
 use \Exception;
+use Model\CreatureModel;
+use Model\FloorModel;
 use Slim\Exception\NotFoundException;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -74,7 +76,7 @@ class ItemsController extends Controller
     public function commonItem(Request $request, Response $response, array $args)
     {
         $this->title = ucfirst($args['itemClassName']) . ' ノーマルアイテム';
-        $this->scripts[] = '/js/item.js?id=00047';
+        $this->scripts[] = '/js/item.js?id=00075';
 
         try {
             $this->db->beginTransaction();
@@ -105,13 +107,16 @@ class ItemsController extends Controller
 
     public function detail(Request $request, Response $response, array $args)
     {
-        $item = new ItemModel($this->db, $this->logger);
+        $floor = new FloorModel($this->db, $this->logger);
+        $creature = new CreatureModel($this->db, $this->logger);
         $quest = new QuestModel($this->db, $this->logger);
         $shop = new ShopModel($this->db, $this->logger);
         $tag = new TagModel($this->db, $this->logger);
-        $detail = $item->getItemDetailById($args['itemId']);
         $data = [
-            'item' => $detail,
+            'floors' => $floor->getFloorsByItemId($args['itemId']),
+            'banana' => $floor->getBananaFloorsByItemId($args['itemId']),
+            'treasure' => $floor->getTreasureFloorsByItemId($args['itemId']),
+            'creatures' => $creature->getCreaturesByItemId($args['itemId']),
             'quests' => $quest->getQuestDetailListByItemId($args['itemId']),
             'shops' => $shop->getShopListByItemId($args['itemId']),
             'tags' => $tag->getTagsByItemId($args['itemId'])

--- a/src/classes/controller/TagController.php
+++ b/src/classes/controller/TagController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Controller;
+
+use \Exception;
+use Model\ItemModel;
+use Model\TagModel;
+use Slim\Exception\NotFoundException;
+use Slim\Http\Request;
+use Slim\Http\Response;
+
+/**
+ * タグ コントローラ.
+ */
+class TagController extends Controller
+{
+
+    public function index(Request $request, Response $response, array $args)
+    {
+        $this->title = 'タグ';
+
+        try {
+            $this->db->beginTransaction();
+
+            $tag = new TagModel($this->db, $this->logger);
+
+            $args = [
+                'header' => $this->getHeaderInfo(),
+                'tags' => $tag->getTags(),
+                'footer' => $this->getFooterInfo()
+            ];
+
+            $this->db->commit();
+        } catch (Exception $e) {
+            $this->db->rollBack();
+            throw $e;
+        }
+
+        return $this->renderer->render($response, 'tags/index.phtml', $args);
+    }
+
+    public function detail(Request $request, Response $response, array $args)
+    {
+        try {
+            $this->db->beginTransaction();
+
+            $tag = new TagModel($this->db, $this->logger);
+            $item = new ItemModel($this->db, $this->logger);
+            $detail = $tag->getTagByTagurl($args['tagUrl']);
+
+            if ($detail == null) throw new NotFoundException($request, $response);
+
+            $this->title = 'タグ:' . $detail['tag_name'];
+
+            $args = [
+                'header' => $this->getHeaderInfo(),
+                'detail' => $detail,
+                'items' => $item->getItemsByTag($args['tagUrl']),
+                'footer' => $this->getFooterInfo()
+            ];
+
+            $this->db->commit();
+        } catch (Exception $e) {
+            $this->db->rollBack();
+            throw $e;
+        }
+
+        return $this->renderer->render($response, 'tags/tag.phtml', $args);
+    }
+}

--- a/src/classes/model/FloorModel.php
+++ b/src/classes/model/FloorModel.php
@@ -7,8 +7,6 @@ use \PDO;
 class FloorModel extends Model
 {
 
-    private const RARITY_RARE = "rare";
-
     public function getFloorIndex()
     {
         $floorIndex = [];
@@ -25,7 +23,7 @@ class FloorModel extends Model
         return $floorIndex;
     }
 
-    public function getFloorDetail($floorId)
+    public function getFloorDetail(int $floorId)
     {
         $sql = <<<SQL
             SELECT
@@ -52,14 +50,139 @@ class FloorModel extends Model
                 'name_ja' => $result['name_ja'],
                 'image_name' => $result['image_name'],
                 'image_size' => $result['image_size'],
-                'items' => $this->getFloorRareItemList($floorId),
-                'banana' => $this->getFloorBananaItemList($floorId),
-                'treasure' => $this->getFloorTreasureItemList($floorId),
-                'creatures' => $this->getFloorCreatureList($floorId)
             ];
         } else {
             return null;
         }
+    }
+
+    public function getFloorsByItemId(int $itemId)
+    {
+        $sql = <<<SQL
+            SELECT DISTINCT
+                F.floor_id
+                , F.short_name
+            FROM
+                floor_drop_group FG
+                INNER JOIN floor F
+                    ON FG.floor_id = F.floor_id
+                INNER JOIN drop_item_group IG
+                    ON IG.drop_item_group_id = FG.drop_item_group_id
+            WHERE
+                IG.item_id = :id
+            ORDER BY
+                F.sort_key
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':id', $itemId, PDO::PARAM_INT);
+        $stmt->execute();
+        $floors = [];
+        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $floors[] = [
+                'floor_id' => $result['floor_id'],
+                'short_name' => $result['short_name'],
+            ];
+        }
+        return $floors;
+    }
+
+    public function getBananaFloorsByItemId(int $itemId)
+    {
+        $sql = <<<SQL
+            SELECT DISTINCT
+                F.floor_id
+                , F.short_name
+            FROM
+                floor_banana_drop_group FG
+                INNER JOIN drop_item_group DG
+                    ON FG.drop_item_group_id = DG.drop_item_group_id
+                INNER JOIN floor F
+                    ON FG.floor_id = F.floor_id
+            WHERE
+                DG.item_id = :id
+            ORDER BY
+                F.sort_key
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':id', $itemId, PDO::PARAM_INT);
+        $stmt->execute();
+        $floors = [];
+        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $floors[] = [
+                'floor_id' => $result['floor_id'],
+                'short_name' => $result['short_name'],
+            ];
+        }
+        return $floors;
+    }
+
+    public function getTreasureFloorsByItemId(int $itemId)
+    {
+        $sql = <<<SQL
+            SELECT
+                F.floor_id
+                , F.short_name
+                , FT.note
+            FROM
+                floor_treasure FT
+                INNER JOIN floor F
+                    ON FT.floor_id = F.floor_id
+            WHERE
+                FT.item_id = :id
+            ORDER BY
+                F.sort_key
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':id', $itemId, PDO::PARAM_INT);
+        $stmt->execute();
+        $floors = [];
+        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $floors[] = [
+                'floor_id' => $result['floor_id'],
+                'short_name' => $result['short_name'],
+                'note' => $result['note'],
+            ];
+        }
+        return $floors;
+    }
+
+    public function getFloorsByCreatureId(int $creatureId)
+    {
+        $sql = <<<SQL
+            SELECT
+                F.floor_id
+                , F.short_name
+                , F.name_en
+                , E.note
+            FROM
+                floor_creature FC
+                INNER JOIN floor F
+                    ON FC.floor_id = F.floor_id
+                LEFT JOIN creature_pop_event E
+                    ON FC.event_id = E.event_id
+            WHERE
+                FC.creature_id = :id
+            ORDER BY
+                F.sort_key
+                , E.event_id
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':id', $creatureId, PDO::PARAM_INT);
+        $stmt->execute();
+        $floors = [];
+        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $floors[] = [
+                'floor_id' => $result['floor_id'],
+                'short_name' => $result['short_name'],
+                'name_en' => $result['name_en'],
+                'note' => $result['note'],
+            ];
+        }
+        return $floors;
     }
 
     private function getFloorGroupList()
@@ -117,201 +240,5 @@ class FloorModel extends Model
             ];
         }
         return $floors;
-    }
-
-    private function getFloorRareItemList($floorId)
-    {
-        $rarity = self::RARITY_RARE;
-        $sql = <<<SQL
-            SELECT DISTINCT
-                I.item_id
-                , IC.name_en item_class
-                , I.base_item_id
-                , I.class_flactuable
-                , I.name_en
-                , I.name_ja
-                , I.rarity
-                , I.image_name
-            FROM
-                floor_drop_group FG
-                INNER JOIN drop_item_group DG
-                    ON FG.drop_item_group_id = DG.drop_item_group_id
-                INNER JOIN item I
-                    ON DG.item_id = I.item_id
-                INNER JOIN item_class IC
-                    ON I.item_class_id = IC.item_class_id
-            WHERE
-                FG.floor_id = :floor_id
-                AND I.rarity = :rarity
-            ORDER BY
-                I.sort_key
-                , I.item_id
-            SQL;
-        $this->logger->debug($sql);
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':floor_id', $floorId, PDO::PARAM_INT);
-        $stmt->bindParam(':rarity', $rarity, PDO::PARAM_STR);
-        $stmt->execute();
-        $items = [];
-        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $items[] = [
-                'item_id' => $result['item_id'],
-                'item_class' => $result['item_class'],
-                'base_item_id' => $result['base_item_id'],
-                'class_flactuable' => $result['class_flactuable'],
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'rarity' => $result['rarity'],
-                'image_name' => $result['image_name'],
-            ];
-        }
-        return $items;
-    }
-
-    private function getFloorBananaItemList($floorId)
-    {
-        $sql = <<<SQL
-            SELECT DISTINCT
-                I.item_id
-                , IC.name_en item_class
-                , I.base_item_id
-                , I.class_flactuable
-                , I.name_en
-                , I.name_ja
-                , I.rarity
-                , I.image_name
-            FROM
-                floor_banana_drop_group FG
-                INNER JOIN drop_item_group DG
-                    ON FG.drop_item_group_id = DG.drop_item_group_id
-                INNER JOIN item I
-                    ON DG.item_id = I.item_id
-                INNER JOIN item_class IC
-                    ON I.item_class_id = IC.item_class_id
-            WHERE
-                FG.floor_id = :floor_id
-                AND rarity IN ('rare', 'artifact')
-            ORDER BY
-                I.sort_key
-                , I.item_id
-            SQL;
-        $this->logger->debug($sql);
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':floor_id', $floorId, PDO::PARAM_INT);
-        $stmt->execute();
-        $items = [];
-        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $items[] = [
-                'item_id' => $result['item_id'],
-                'item_class' => $result['item_class'],
-                'base_item_id' => $result['base_item_id'],
-                'class_flactuable' => $result['class_flactuable'],
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'rarity' => $result['rarity'],
-                'image_name' => $result['image_name'],
-            ];
-        }
-        return $items;
-    }
-
-    private function getFloorTreasureItemList($floorId)
-    {
-        $sql = <<<SQL
-            SELECT
-                I.item_id
-                , IC.name_en item_class
-                , I.base_item_id
-                , I.name_en
-                , I.name_ja
-                , I.rarity
-                , I.image_name
-                , FT.note
-            FROM
-                floor_treasure FT
-                INNER JOIN item I
-                    ON FT.item_id = I.item_id
-                INNER JOIN item_class IC
-                    ON I.item_class_id = IC.item_class_id
-            WHERE
-                FT.floor_id = :floor_id
-            ORDER BY
-                I.sort_key
-                , I.item_id
-            SQL;
-        $this->logger->debug($sql);
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':floor_id', $floorId, PDO::PARAM_INT);
-        $stmt->execute();
-        $items = [];
-        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $items[] = [
-                'item_id' => $result['item_id'],
-                'item_class' => $result['item_class'],
-                'base_item_id' => $result['base_item_id'],
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'rarity' => $result['rarity'],
-                'image_name' => $result['image_name'],
-                'note' => $result['note'],
-            ];
-        }
-        return $items;
-    }
-
-    private function getFloorCreatureList($floorId)
-    {
-        $sql = <<<SQL
-            SELECT
-                FC.event_id
-                , E.note
-                , C.creature_id
-                , C.boss
-                , C.name_en
-                , C.name_ja
-                , C.image_name
-            FROM
-                floor_creature FC
-                INNER JOIN creature C
-                    ON FC.creature_id = C.creature_id
-                LEFT JOIN creature_pop_event E
-                    ON FC.event_id = E.event_id
-            WHERE
-                FC.floor_id = :floor_id
-            ORDER BY
-                FC.event_id
-                , C.boss
-                , C.sort_key
-            SQL;
-        $this->logger->debug($sql);
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':floor_id', $floorId, PDO::PARAM_INT);
-        $stmt->execute();
-        $floorCreatures = [
-            'default' => [],
-            'events' => []
-        ];
-        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $creature = [
-                'creature_id' => $result['creature_id'],
-                'boss' => $result['boss'],
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'image_name' => $result['image_name']
-            ];
-            $eventId = $result['event_id'];
-            if ($eventId == 0) {
-                $floorCreatures['default'][] = $creature;
-            } else {
-                if (!array_key_exists($eventId, $floorCreatures['events'])) {
-                    $floorCreatures['events'][$eventId] = [
-                        'note' => $result['note'],
-                        'creatures' => []
-                    ];
-                }
-                $floorCreatures['events'][$eventId]['creatures'][] = $creature;
-            }
-        }
-        return $floorCreatures;
     }
 }

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -429,6 +429,53 @@ class ItemModel extends Model
         }
     }
 
+    public function getItemsByTag(string $tagUrl)
+    {
+        $sql = <<<SQL
+            SELECT
+                I.item_id
+                , I.item_class_id
+                , IC.name_en item_class
+                , I.base_item_id
+                , I.class_flactuable
+                , I.name_en
+                , I.name_ja
+                , I.rarity
+                , I.image_name
+            FROM
+                item I
+                LEFT JOIN item_class IC
+                    ON I.item_class_id = IC.item_class_id
+                LEFT JOIN item_tag IT
+                    ON I.item_id = IT.item_id
+                LEFT JOIN tag T
+                    ON IT.tag_id = T.tag_id
+            WHERE
+                T.tag_url = :tagUrl
+            ORDER BY
+                I.sort_key
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':tagUrl', $tagUrl, PDO::PARAM_STR);
+        $stmt->execute();
+        $items = [];
+        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $items[] = [
+                'item_id' => $result['item_id'],
+                'item_class_id' => $result['item_class_id'],
+                'item_class' => $result['item_class'],
+                'base_item_id' => $result['base_item_id'],
+                'class_flactuable' => $result['class_flactuable'],
+                'name_en' => $result['name_en'],
+                'name_ja' => $result['name_ja'],
+                'rarity' => $result['rarity'],
+                'image_name' => $result['image_name'],
+            ];
+        }
+        return $items;
+    }
+
     public function getNone($itemClass)
     {
         return [

--- a/src/classes/model/QuestModel.php
+++ b/src/classes/model/QuestModel.php
@@ -53,8 +53,6 @@ class QuestModel extends Model
                 'reward_common_items' => $result['reward_common_items'],
                 'note' => $result['note'],
                 'icons' => $this->getQuestIcons($result['quest_id']),
-                'required_items' => $this->getQuestRequiredItems($result['quest_id']),
-                'reward_items' => $this->getQuestRewardItems($result['quest_id']),
             ];
         }
         return $quests;
@@ -135,97 +133,5 @@ class QuestModel extends Model
             ];
         }
         return $icons;
-    }
-
-    private function getQuestRequiredItems($questId)
-    {
-        $sql = <<<SQL
-            SELECT
-                I.item_id
-                , I.item_class_id
-                , IC.name_en item_class
-                , I.base_item_id
-                , I.class_flactuable
-                , I.name_en
-                , I.name_ja
-                , I.rarity
-                , I.image_name
-            FROM
-                quest_required_item QRI
-                INNER JOIN item I
-                    ON QRI.item_id = I.item_id
-                INNER JOIN item_class IC
-                    ON I.item_class_id = IC.item_class_id
-            WHERE
-                QRI.quest_id = :quest_id
-            ORDER BY
-                I.sort_key
-                , I.item_id
-            SQL;
-        $this->logger->debug($sql);
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':quest_id', $questId, PDO::PARAM_INT);
-        $stmt->execute();
-        $items = [];
-        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $items[] = [
-                'item_id' => $result['item_id'],
-                'item_class_id' => $result['item_class_id'],
-                'item_class' => $result['item_class'],
-                'base_item_id' => $result['base_item_id'],
-                'class_flactuable' => $result['class_flactuable'],
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'rarity' => $result['rarity'],
-                'image_name' => $result['image_name'],
-            ];
-        }
-        return $items;
-    }
-
-    private function getQuestRewardItems($questId)
-    {
-        $sql = <<<SQL
-            SELECT
-                I.item_id
-                , I.item_class_id
-                , IC.name_en item_class
-                , I.base_item_id
-                , I.class_flactuable
-                , I.name_en
-                , I.name_ja
-                , I.rarity
-                , I.image_name
-            FROM
-                quest_reward_item QRI
-                INNER JOIN item I
-                    ON QRI.item_id = I.item_id
-                INNER JOIN item_class IC
-                    ON I.item_class_id = IC.item_class_id
-            WHERE
-                QRI.quest_id = :quest_id
-            ORDER BY
-                I.sort_key
-                , I.item_id
-            SQL;
-        $this->logger->debug($sql);
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':quest_id', $questId, PDO::PARAM_INT);
-        $stmt->execute();
-        $items = [];
-        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $items[] = [
-                'item_id' => $result['item_id'],
-                'item_class_id' => $result['item_class_id'],
-                'item_class' => $result['item_class'],
-                'base_item_id' => $result['base_item_id'],
-                'class_flactuable' => $result['class_flactuable'],
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'rarity' => $result['rarity'],
-                'image_name' => $result['image_name'],
-            ];
-        }
-        return $items;
     }
 }

--- a/src/classes/model/ShopModel.php
+++ b/src/classes/model/ShopModel.php
@@ -78,57 +78,8 @@ class ShopModel extends Model
                 'image_name' => $result['image_name'],
                 'random' => $result['random'],
                 'note' => $result['note'],
-                'items' => $this->getShopItemList($result['shop_id'])
             ];
         }
         return $shops;
-    }
-
-    private function getShopItemList(int $shopId)
-    {
-        $sql = <<<SQL
-            SELECT
-                I.item_id
-                , I.item_class_id
-                , IC.name_en item_class
-                , I.base_item_id
-                , I.name_en
-                , I.name_ja
-                , I.rarity
-                , I.image_name
-                , I.sort_key
-                , SI.price
-            FROM
-                shop_item SI
-                INNER JOIN item I
-                    ON SI.item_id = I.item_id
-                INNER JOIN item_class IC
-                    ON I.item_class_id = IC.item_class_id
-            WHERE
-                SI.shop_id = :shop_id
-            ORDER BY
-                IC.shop_sort_key
-                , I.sort_key
-            SQL;
-        $this->logger->debug($sql);
-        $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':shop_id', $shopId, PDO::PARAM_INT);
-        $stmt->execute();
-        $items = [];
-        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $items[] = [
-                'item_id' => $result['item_id'],
-                'item_class_id' => $result['item_class_id'],
-                'item_class' => $result['item_class'],
-                'base_item_id' => $result['base_item_id'],
-                'name_en' => $result['name_en'],
-                'name_ja' => $result['name_ja'],
-                'rarity' => $result['rarity'],
-                'image_name' => $result['image_name'],
-                'sort_key' => $result['sort_key'],
-                'price' => $result['price']
-            ];
-        }
-        return $items;
     }
 }

--- a/src/classes/model/TagModel.php
+++ b/src/classes/model/TagModel.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Model;
+
+use \PDO;
+
+class TagModel extends Model
+{
+
+    public function getTags()
+    {
+        $sql = <<<SQL
+            SELECT
+                tag_id
+                , tag_url
+                , tag_name
+            FROM
+                tag T
+            ORDER BY
+                T.sort_key
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute();
+        $tags = [];
+        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $tags[] = [
+                'tag_id' => $result['tag_id'],
+                'tag_url' => $result['tag_url'],
+                'tag_name' => $result['tag_name'],
+            ];
+        }
+        return $tags;
+    }
+
+    public function getTagByTagUrl(string $tagUrl)
+    {
+        $sql = <<<SQL
+            SELECT
+                tag_id
+                , tag_url
+                , tag_name
+            FROM
+                tag
+            WHERE
+                tag_url = :tagUrl
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':tagUrl', $tagUrl, PDO::PARAM_STR);
+        $stmt->execute();
+        if ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            return [
+                'tag_id' => $result['tag_id'],
+                'tag_url' => $result['tag_url'],
+                'tag_name' => $result['tag_name'],
+            ];
+        } else {
+            return null;
+        }
+    }
+
+    public function getTagsByItemId(int $itemId)
+    {
+        $sql = <<<SQL
+            SELECT
+                T.tag_id
+                , T.tag_url
+                , T.tag_name
+            FROM
+                tag T
+                JOIN item_tag IT
+                    ON T.tag_id = IT.tag_id
+                JOIN item I
+                    ON IT.item_id = I.item_id
+            WHERE
+                I.item_id = :itemId
+            ORDER BY
+                T.sort_key
+            SQL;
+        $this->logger->debug($sql);
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':itemId', $itemId, PDO::PARAM_INT);
+        $stmt->execute();
+        $tags = [];
+        while ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $tags[] = [
+                'tag_id' => $result['tag_id'],
+                'tag_url' => $result['tag_url'],
+                'tag_name' => $result['tag_name'],
+            ];
+        }
+        return $tags;
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -9,6 +9,7 @@ use Controller\CreaturesController;
 use Controller\FloorsController;
 use Controller\SimulatorController;
 use Controller\ShortURLController;
+use Controller\TagController;
 
 return function (App $app) {
     $container = $app->getContainer();
@@ -44,6 +45,10 @@ return function (App $app) {
     $app->get('/simulator', SimulatorController::class . ':index');
 
     $app->get('/simulator/item/{itemClassName}', SimulatorController::class . ':item');
+
+    $app->get('/tags', TagController::class . ':index');
+
+    $app->get('/tags/{tagUrl}', TagController::class . ':detail');
 
     $app->get('/s', ShortURLController::class . ':index');
 

--- a/templates/floors/floor.phtml
+++ b/templates/floors/floor.phtml
@@ -29,12 +29,12 @@
       <div class="lemonchiffon">Rare Items</div>
       <table class="table-dark table-striped table-bordered w-100 mb-2">
         <tbody>
-          <?php if (empty($detail['items'])) : ?>
+          <?php if (empty($items)) : ?>
             <tr>
               <td>No Items</td>
             </tr>
           <?php endif; ?>
-          <?php foreach ($detail['items'] as $item) : ?>
+          <?php foreach ($items as $item) : ?>
             <tr>
               <td>
                 <a href="/items/<?= strtolower($item['item_class']) ?>/<?= $item['rarity'] == 'common' ? $item['base_item_id'] : 'rare' ?>/<?= $item['item_id'] ?>" class="<?= $item['rarity'] ?>">
@@ -48,11 +48,11 @@
           <?php endforeach; ?>
         </tbody>
       </table>
-      <?php if (!empty($detail['banana'])) : ?>
+      <?php if (!empty($banana)) : ?>
         <div class="lemonchiffon">Banana Items</div>
         <table class="table-dark table-striped table-bordered w-100 mb-2">
           <tbody>
-            <?php foreach ($detail['banana'] as $item) : ?>
+            <?php foreach ($banana as $item) : ?>
               <tr>
                 <td>
                   <a href="/items/<?= strtolower($item['item_class']) ?>/<?= $item['rarity'] == 'common' ? $item['base_item_id'] : 'rare' ?>/<?= $item['item_id'] ?>" class="<?= $item['rarity'] ?>">
@@ -178,11 +178,11 @@
           </tbody>
         </table>
       <?php endif; ?>
-      <?php if (!empty($detail['treasure'])) : ?>
+      <?php if (!empty($treasure)) : ?>
         <div class="lemonchiffon">Treasure Items</div>
         <table class="table-dark table-striped table-bordered w-100 mb-2">
           <tbody>
-            <?php foreach ($detail['treasure'] as $item) : ?>
+            <?php foreach ($treasure as $item) : ?>
               <tr>
                 <td>
                   <a href="/items/<?= strtolower($item['item_class']) ?>/<?= $item['rarity'] == 'common' ? $item['base_item_id'] : 'rare' ?>/<?= $item['item_id'] ?>" class="<?= $item['rarity'] ?>">
@@ -200,12 +200,12 @@
       <div class="lemonchiffon">Creatures</div>
       <table class="table-dark table-striped table-bordered w-100 mb-2">
         <tbody>
-          <?php if (empty($detail['creatures']['default'])) : ?>
+          <?php if (empty($creatures['default'])) : ?>
             <tr>
               <td>No Creatures</td>
             </tr>
           <?php endif; ?>
-          <?php foreach ($detail['creatures']['default'] as $creature) : ?>
+          <?php foreach ($creatures['default'] as $creature) : ?>
             <tr>
               <td>
                 <a href="/creatures/<?= $creature['creature_id'] ?>" class="<?= $creature['boss'] ? 'boss' : 'text-light' ?>">
@@ -216,12 +216,12 @@
           <?php endforeach; ?>
         </tbody>
       </table>
-      <?php if (!empty($detail['creatures']['events'])) : ?>
+      <?php if (!empty($creatures['events'])) : ?>
         <div>
           <a href="#collapse-creatures" class="lemonchiffon collapse-link" data-toggle="collapse" aria-expanded="false" aria-controls="collapse-creatures">Additional Creatures<i class="fas fa-chevron-circle-down"></i></a>
         </div>
         <div class="collapse" id="collapse-creatures">
-          <?php foreach ($detail['creatures']['events'] as $event) : ?>
+          <?php foreach ($creatures['events'] as $event) : ?>
             <div class="lemonchiffon"><?= $event['note'] ?></div>
             <table class="table-dark table-striped table-bordered w-100 mb-2">
               <tbody>

--- a/templates/header.phtml
+++ b/templates/header.phtml
@@ -21,7 +21,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-  <link rel="stylesheet" href="/css/main.css?id=00071">
+  <link rel="stylesheet" href="/css/main.css?id=00075">
   <link rel="stylesheet" href="/lib/photoswipe/photoswipe.css">
   <link rel="stylesheet" href="/lib/photoswipe/default-skin/default-skin.css">
   <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-12 col-md-6 col-xl-4 mb-3">
     <div class="card bg-darkblue">
-      <h5 class="card-header border-secondary">News</h5>
+      <h5 class="card-header border-secondary">News and Updates</h5>
       <?php foreach ($newsList as $news) : ?>
         <div class="card-body border-bottom border-secondary">
           <h5 class="card-title"><?= $news['post_date'] ?></h5>

--- a/templates/items/detail.phtml
+++ b/templates/items/detail.phtml
@@ -116,7 +116,7 @@
         </div>
         <div class="row">
           <div class="col-12 mb-3">
-            <div>Used for Quests</div>
+            <div>Usage for Quests</div>
             <ul class="list-unstyled m-0 small" id="detail-quest-required">
               <template id="modal-quest-required-row">
                 <li class="detail-row my-1">

--- a/templates/items/detail.phtml
+++ b/templates/items/detail.phtml
@@ -115,7 +115,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-12">
+          <div class="col-12 mb-3">
             <div>Used for Quests</div>
             <ul class="list-unstyled m-0 small" id="detail-quest-required">
               <template id="modal-quest-required-row">
@@ -129,6 +129,19 @@
                 </li>
               </template>
               <li id="detail-quest-required-none" class="pl-1">None</li>
+            </ul>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-12">
+            <div>Tags</div>
+            <ul class="list-inline m-0 small" id="detail-tags">
+              <template id="modal-tag-row">
+                <li class="detail-row list-inline-item my-1">
+                  <a class="tag-name badge badge-pill badge-secondary"></a>
+                </li>
+              </template>
+              <li id="detail-tags-none" class="pl-1">None</li>
             </ul>
           </div>
         </div>

--- a/templates/news/index.phtml
+++ b/templates/news/index.phtml
@@ -4,7 +4,7 @@
 <div class="row">
   <div class="col-12 mb-3">
     <div class="card bg-darkblue">
-      <h5 class="card-header border-secondary">News</h5>
+      <h5 class="card-header border-secondary">News and Updates</h5>
       <?php foreach ($news['list'] as $n) : ?>
         <div class="card-body border-bottom border-secondary">
           <h5 class="card-title"><?= $n['post_date'] ?></h5>

--- a/templates/tags/index.phtml
+++ b/templates/tags/index.phtml
@@ -3,7 +3,7 @@
 <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
 <div class="card mb-2 bg-darkblue">
   <div class="card-body">
-    <ul class="list-inline mb-4">
+    <ul class="list-inline mb-0">
       <?php foreach ($tags as $tag) : ?>
         <li class="list-inline-item">
           <a href="/tags/<?= $tag['tag_url'] ?>" class="badge badge-pill badge-secondary mb-1"><?= $tag['tag_name'] ?></a>

--- a/templates/tags/index.phtml
+++ b/templates/tags/index.phtml
@@ -1,0 +1,15 @@
+<?= $this->fetch('header.phtml', ['header' => $header]) ?>
+<h2>Tags</h2>
+<?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
+<div class="card mb-2 bg-darkblue">
+  <div class="card-body">
+    <ul class="list-inline mb-4">
+      <?php foreach ($tags as $tag) : ?>
+        <li class="list-inline-item">
+          <a href="/tags/<?= $tag['tag_url'] ?>" class="badge badge-pill badge-secondary mb-1"><?= $tag['tag_name'] ?></a>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  </div>
+</div>
+<?= $this->fetch('footer.phtml', ['footer' => $footer]) ?>

--- a/templates/tags/tag.phtml
+++ b/templates/tags/tag.phtml
@@ -1,0 +1,35 @@
+<?= $this->fetch('header.phtml', ['header' => $header]) ?>
+<div>
+  <a href="/tags" class="lemonchiffon"><i class="fas fa-chevron-circle-left"></i>All Tags</a>
+</div>
+<h2><?= $detail['tag_name'] ?></h2>
+<?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
+<div class="container">
+  <div class="row">
+    <div class="col-12 col-sm-6">
+      <h4>Items</h4>
+      <table class="table-dark table-striped table-bordered w-100 mb-2">
+        <tbody>
+          <?php if (empty($items)) : ?>
+            <tr>
+              <td>No Items</td>
+            </tr>
+          <?php endif; ?>
+          <?php foreach ($items as $item) : ?>
+            <tr>
+              <td>
+                <a href="/items/<?= strtolower($item['item_class']) ?>/<?= $item['rarity'] == 'common' ? $item['base_item_id'] : 'rare' ?>/<?= $item['item_id'] ?>" class="<?= $item['rarity'] ?>">
+                  <img class="item-icon" src="/img/item/<?= $item['image_name'] ?>" /><span class="pl-1"><?= $item['name_en'] ?></span>
+                </a>
+                <?php if ($item['class_flactuable']) : ?>
+                  <img class="class-icon" src="/img/common/<?= strtolower($item['item_class']) ?>.png" />
+                <?php endif; ?>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<?= $this->fetch('footer.phtml', ['footer' => $footer]) ?>


### PR DESCRIPTION
# 新機能追加：ページタグ・タグ検索

- 各ページにタグを付与し、同一のタグが付与されたページの一覧を検索できる
- タグ一覧ページですべてのタグを閲覧できる
- 現在はアイテムデータにのみタグを付与できる

# 表示項目追加

- アイテムデータにタグの項目を追加

# 文言の変更

- アイテムデータ : Used for Quests => Usage for Quests
- トップページ・Newsページ : News => News and Updates

# 内部処理の改善

- リファクタリング実施
- APIレスポンスの形式を一部変更