### PR TITLE
シミュレータにアイテムデータへのリンクを追加

### DIFF
--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -287,6 +287,13 @@ $(function () {
         .addClass("d-none")
         .attr("title", "");
     }
+    if (item.item_id) {
+      link.closest("div.d-table-row").find(".item-link")
+        .attr("href", "/items/" + item.item_class_name + "/" + (item.rarity == "common" ? item.base_item_id : "rare") + "/" + item.item_id);
+    } else {
+      link.closest("div.d-table-row").find(".item-link")
+        .addClass("d-none");
+    }
     link.children().remove();
     link.append(img);
     link.closest("div.d-table-row").find(".attr").children().remove();

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -23,7 +23,7 @@ class SimulatorController extends Controller
     public function index(Request $request, Response $response)
     {
         $this->title = 'シミュレータ';
-        $this->scripts[] = '/js/simulator.js?id=00071';
+        $this->scripts[] = '/js/simulator.js?id=00076';
         $item = new ItemModel($this->db, $this->logger);
         $getParam = $request->getQueryParams();
         $charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -26,6 +26,7 @@ class ItemModel extends Model
         I.item_id
         , I.item_class_id
         , IC.name_en item_class_name
+        , I.base_item_id
         , I.image_name
         , I.name_en
         , I.name_ja
@@ -697,6 +698,7 @@ class ItemModel extends Model
                 $item['item_id'] = $result['item_id'];
                 $item['item_class_id'] = $result['item_class_id'];
                 $item['item_class_name'] = strtolower($result['item_class_name']);
+                $item['base_item_id'] = $result['base_item_id'];
                 $item['image_name'] = ($result['image_name'] === null)
                     ? "item_noimg.png" : $result['image_name'];
                 $item['name_en'] = $result['name_en'];

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -106,7 +106,7 @@
                         </div>
                         <div class="d-table-cell align-top">
                           <div class="pl-1">
-                            <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a>
+                            <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a><a href="javascript:void(0);" target="_blank" class="item-link text-light pl-5"><i class="fas fa-external-link-alt"></i></a>
                           </div>
                           <div class="d-table w-100 small table-item-attrs">
                             <div class="d-table-row">


### PR DESCRIPTION
# 機能追加 : シミュレータにアイテムデータへのリンクを追加

- アイテム選択欄にアイテムデータへの別タブリンクを追加
- シミュレータで表示できるすべてのアイテムについて対応