### PR TITLE
シミュレータにビルド保存機能を追加

### DIFF
--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -292,9 +292,11 @@ $(function () {
     }
     if (item.item_id) {
       link.closest("div.d-table-row").find(".item-link")
-        .attr("href", "/items/" + item.item_class_name + "/" + (item.rarity == "common" ? item.base_item_id : "rare") + "/" + item.item_id);
+        .attr("href", "/items/" + item.item_class_name + "/" + (item.rarity == "common" ? item.base_item_id : "rare") + "/" + item.item_id)
+        .removeClass("d-none");
     } else {
       link.closest("div.d-table-row").find(".item-link")
+        .attr("href", "#")
         .addClass("d-none");
     }
     link.children().remove();

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -23,7 +23,7 @@ class SimulatorController extends Controller
     public function index(Request $request, Response $response)
     {
         $this->title = 'シミュレータ';
-        $this->scripts[] = '/js/simulator.js?id=00076';
+        $this->scripts[] = '/js/simulator.js?id=00077';
         $item = new ItemModel($this->db, $this->logger);
         $getParam = $request->getQueryParams();
         $charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -26,7 +26,7 @@
                   <a href="javascript:void(0);" class="lemonchiffon link-save"><i class="fas fa-save"></i>Save / Load</a>
                 </div>
                 <div>
-                  <input type="text" class="form-control p-0 h-auto pr-2 text-share" />
+                  <input type="text" name="text-share" class="form-control p-0 h-auto pr-2 text-share" />
                 </div>
               </div>
             </td>
@@ -216,7 +216,7 @@
                     </div>
                     <div class="d-table-cell align-top">
                       <div class="pl-1">
-                        <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a>
+                        <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a><a href="javascript:void(0);" target="_blank" class="item-link text-light ml-5"><i class="fas fa-external-link-alt"></i></a>
                       </div>
                       <div class="d-table w-100 small table-item-attrs">
                         <?= $this->fetch('simulator/itemStatsRow.phtml') ?>

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -6,6 +6,7 @@
   <h2>Simulator</h2>
   <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
   <?= $this->fetch('simulator/itemModal.phtml') ?>
+  <?= $this->fetch('simulator/saveModal.phtml') ?>
   <div class="row mb-md-2">
     <div class="col-12 col-md-6 px-1">
       <table class="table-attributes table-dark table-striped w-100 small">
@@ -17,10 +18,17 @@
         <tbody>
           <tr>
             <td colspan="3">
-              <label class="w-100 mb-0">
-                <a href="javascript:void(0);" class="lemonchiffon link-share ml-1"><i class="fas fa-share-square"></i>Share by URL</a><br />
-                <input type="text" class="form-control p-0 h-auto pr-2 text-share" />
-              </label>
+              <div class="w-100 mb-0">
+                <div class="w-45 d-inline-block">
+                  <a href="javascript:void(0);" class="lemonchiffon link-share ml-1"><i class="fas fa-share-square"></i>Share by URL</a>
+                </div>
+                <div class="w-50 d-inline-block ml-2 text-right">
+                  <a href="javascript:void(0);" class="lemonchiffon link-save"><i class="fas fa-save"></i>Save / Load</a>
+                </div>
+                <div>
+                  <input type="text" class="form-control p-0 h-auto pr-2 text-share" />
+                </div>
+              </div>
             </td>
           </tr>
           <tr>

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -5,169 +5,7 @@
 <div class="container">
   <h2>Simulator</h2>
   <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
-  <div class="modal fade" id="modal-items" tabindex="-1" role="dialog" aria-labelledby="modal-itemsTitle" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
-      <div class="modal-content bg-darkgreen">
-        <div class="modal-header">
-          <h4 class="modal-title" id="modal-itemsTitle">Select Item</h4>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true" class="button-close-white">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body overflow-auto">
-          <div>
-            <a href="#collapse-search" class="lemonchiffon" data-toggle="collapse" aria-expanded="true" aria-controls="collapseExample"><i class="fas fa-search"></i>Search</a>
-          </div>
-          <div class="collapse show" id="collapse-search">
-            <div class="card mb-2 bg-darkblue">
-              <div class="card-body p-2">
-                <div class="form-check form-check-inline">
-                  <input id="search-rarity-common" class="form-check-input" type="checkbox" value="true" />
-                  <label class="form-check-label small" for="search-rarity-common">Common</label>
-                </div>
-                <div class="form-check form-check-inline">
-                  <input id="search-rarity-rare" class="form-check-input" type="checkbox" value="true" />
-                  <label class="form-check-label small rare" for="search-rarity-rare">Rare</label>
-                </div>
-                <div class="form-check form-check-inline">
-                  <input id="search-rarity-artifact" class="form-check-input" type="checkbox" value="true" />
-                  <label class="form-check-label small artifact" for="search-rarity-artifact">Artifact</label>
-                </div>
-                <div class="text-right">
-                  <a href="javascript:void(0);" class="lemonchiffon" id="link-search-submit" data-item-slot=""><i class="far fa-check-circle"></i>Submit</a>
-                </div>
-              </div>
-            </div>
-          </div>
-          <table id="table-items" class="table-dark table-striped w-100 small mt-2" style="min-width: 420px;">
-            <thead>
-              <tr>
-                <td>
-                  <div class="d-table w-100">
-                    <div class="d-table-row">
-                      <div class="d-table-cell text-center align-middle" style="width: 32px;">
-                        <a href="javascript:void(0);" class="thead-sort item-skill" data-attr="Skill"><i class="fas fa-exclamation-circle"></i></a>
-                      </div>
-                      <div class="d-table-cell">
-                        <div class="d-table w-100 small table-item-attrs">
-                          <div class="d-table-row">
-                            <div class="d-table-cell border border-black text-center w-15 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AD">AD</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AS">AS</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AR">AR</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Str">Str</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Def">Def</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Dex">Dex</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Vit">Vit</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="WS">WS</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="SA">SA</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="VoH">VoH</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="DR">DR</a>
-                            </div>
-                            <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
-                              <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="XPG">XPG</a>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            </thead>
-            <tbody>
-              <template id="modal-item-row">
-                <tr>
-                  <td>
-                    <div class="d-table w-100">
-                      <div class="d-table-row">
-                        <div class="d-table-cell align-middle" style="width: 32px;">
-                          <a href="javascript:void(0);" class="item-img"></a>
-                        </div>
-                        <div class="d-table-cell align-top">
-                          <div class="pl-1">
-                            <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a><a href="javascript:void(0);" target="_blank" class="item-link text-light pl-5"><i class="fas fa-external-link-alt"></i></a>
-                          </div>
-                          <div class="d-table w-100 small table-item-attrs">
-                            <div class="d-table-row">
-                              <div class="d-table-cell border border-black text-right w-15">
-                                &nbsp;
-                                <span class="attr attr-minad"></span>
-                                <span class="wave">~</span>
-                                <span class="attr attr-maxad"></span>
-                              </div>
-                              <div class="d-table-cell border border-black text-right w-7-5 attr attr-as"></div>
-                              <div class="d-table-cell border border-black text-right w-8 attr attr-ar"></div>
-                              <div class="d-table-cell border border-black text-right w-8 attr attr-str"></div>
-                              <div class="d-table-cell border border-black text-right w-7-5 attr attr-def"></div>
-                              <div class="d-table-cell border border-black text-right w-7-5 attr attr-dex"></div>
-                              <div class="d-table-cell border border-black text-right w-8 attr attr-vit"></div>
-                              <div class="d-table-cell border border-black text-right w-8 attr attr-ws"></div>
-                              <div class="d-table-cell border border-black text-right w-7-5 attr attr-sa"></div>
-                              <div class="d-table-cell border border-black text-right w-7-5 attr attr-voh"></div>
-                              <div class="d-table-cell border border-black text-right w-8 attr attr-dr"></div>
-                              <div class="d-table-cell border border-black text-right w-7-5 attr attr-xpg"></div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </template>
-              <template id="modal-label-row">
-                <tr>
-                  <td style="padding-left: 33px;">
-                    <div class="d-table w-100 small table-item-attrs">
-                      <div class="d-table-row">
-                        <div class="d-table-cell border border-black text-center w-15">AD</div>
-                        <div class="d-table-cell border border-black text-center w-7-5">AS</div>
-                        <div class="d-table-cell border border-black text-center w-8">AR</div>
-                        <div class="d-table-cell border border-black text-center w-8">Str</div>
-                        <div class="d-table-cell border border-black text-center w-7-5">Def</div>
-                        <div class="d-table-cell border border-black text-center w-7-5">Dex</div>
-                        <div class="d-table-cell border border-black text-center w-8">Vit</div>
-                        <div class="d-table-cell border border-black text-center w-8">WS</div>
-                        <div class="d-table-cell border border-black text-center w-7-5">SA</div>
-                        <div class="d-table-cell border border-black text-center w-7-5">VoH</div>
-                        <div class="d-table-cell border border-black text-center w-8">DR</div>
-                        <div class="d-table-cell border border-black text-center w-7-5">XPG</div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </template>
-            </tbody>
-          </table>
-          <div class="d-flex justify-content-center mt-3" id="scroll-loading">
-            <div class="spinner-border text-lignt" role="status">
-              <span class="sr-only">Loading...</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <?= $this->fetch('simulator/itemModal.phtml') ?>
   <div class="row mb-md-2">
     <div class="col-12 col-md-6 px-1">
       <table class="table-attributes table-dark table-striped w-100 small">
@@ -341,22 +179,7 @@
           <tr>
             <td style="padding-left: 33px;">
               <span style="margin-left: -32px;">Equipment Items</span>
-              <div class="d-table w-100 small table-item-attrs">
-                <div class="d-table-row small">
-                  <div class="d-table-cell border border-black text-center w-15">AD</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">AS</div>
-                  <div class="d-table-cell border border-black text-center w-8">AR</div>
-                  <div class="d-table-cell border border-black text-center w-8">Str</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">Def</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">Dex</div>
-                  <div class="d-table-cell border border-black text-center w-8">Vit</div>
-                  <div class="d-table-cell border border-black text-center w-8">WS</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">SA</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">VoH</div>
-                  <div class="d-table-cell border border-black text-center w-8">DR</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">XPG</div>
-                </div>
-              </div>
+              <?= $this->fetch('simulator/itemAttrsRow.phtml') ?>
             </td>
           </tr>
           <tr>
@@ -388,25 +211,7 @@
                         <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a>
                       </div>
                       <div class="d-table w-100 small table-item-attrs">
-                        <div class="d-table-row">
-                          <div class="d-table-cell border border-black text-right w-15">
-                            &nbsp;
-                            <span class="attr attr-minad"></span>
-                            <span class="wave">~</span>
-                            <span class="attr attr-maxad"></span>
-                          </div>
-                          <div class="d-table-cell border border-black text-right w-7-5 attr attr-as"></div>
-                          <div class="d-table-cell border border-black text-right w-8 attr attr-ar"></div>
-                          <div class="d-table-cell border border-black text-right w-8 attr attr-str"></div>
-                          <div class="d-table-cell border border-black text-right w-7-5 attr attr-def"></div>
-                          <div class="d-table-cell border border-black text-right w-7-5 attr attr-dex"></div>
-                          <div class="d-table-cell border border-black text-right w-8 attr attr-vit"></div>
-                          <div class="d-table-cell border border-black text-right w-8 attr attr-ws"></div>
-                          <div class="d-table-cell border border-black text-right w-7-5 attr attr-sa"></div>
-                          <div class="d-table-cell border border-black text-right w-7-5 attr attr-voh"></div>
-                          <div class="d-table-cell border border-black text-right w-8 attr attr-dr"></div>
-                          <div class="d-table-cell border border-black text-right w-7-5 attr attr-xpg"></div>
-                        </div>
+                        <?= $this->fetch('simulator/itemStatsRow.phtml') ?>
                       </div>
                     </div>
                   </div>
@@ -417,46 +222,13 @@
           <tr>
             <td style="padding-left: 33px;">
               <div class="d-table w-100 small table-item-attrs table-attributes">
-                <div class="d-table-row">
-                  <div class="d-table-cell border border-black text-right w-15">
-                    &nbsp;
-                    <span class="attr attr-minad"></span>
-                    <span class="wave">~</span>
-                    <span class="attr attr-maxad"></span>
-                  </div>
-                  <div class="d-table-cell border border-black text-right w-7-5 attr-as"></div>
-                  <div class="d-table-cell border border-black text-right w-8 attr-ar"></div>
-                  <div class="d-table-cell border border-black text-right w-8 attr-str"></div>
-                  <div class="d-table-cell border border-black text-right w-7-5 attr-def"></div>
-                  <div class="d-table-cell border border-black text-right w-7-5 attr-dex"></div>
-                  <div class="d-table-cell border border-black text-right w-8 attr-vit"></div>
-                  <div class="d-table-cell border border-black text-right w-8 attr-ws"></div>
-                  <div class="d-table-cell border border-black text-right w-7-5 attr-sa"></div>
-                  <div class="d-table-cell border border-black text-right w-7-5 attr-voh"></div>
-                  <div class="d-table-cell border border-black text-right w-8 attr-dr"></div>
-                  <div class="d-table-cell border border-black text-right w-7-5 attr-xpg"></div>
-                </div>
+                <?= $this->fetch('simulator/itemStatsRow.phtml') ?>
               </div>
             </td>
           </tr>
           <tr>
             <td style="padding-left: 33px;">
-              <div class="d-table w-100 small table-item-attrs">
-                <div class="d-table-row small">
-                  <div class="d-table-cell border border-black text-center w-15">AD</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">AS</div>
-                  <div class="d-table-cell border border-black text-center w-8">AR</div>
-                  <div class="d-table-cell border border-black text-center w-8">Str</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">Def</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">Dex</div>
-                  <div class="d-table-cell border border-black text-center w-8">Vit</div>
-                  <div class="d-table-cell border border-black text-center w-8">WS</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">SA</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">VoH</div>
-                  <div class="d-table-cell border border-black text-center w-8">DR</div>
-                  <div class="d-table-cell border border-black text-center w-7-5">XPG</div>
-                </div>
-              </div>
+              <?= $this->fetch('simulator/itemAttrsRow.phtml') ?>
             </td>
           </tr>
         </tbody>

--- a/templates/simulator/itemAttrsRow.phtml
+++ b/templates/simulator/itemAttrsRow.phtml
@@ -1,0 +1,16 @@
+<div class="d-table w-100 small table-item-attrs">
+  <div class="d-table-row small">
+    <div class="d-table-cell border border-black text-center w-15">AD</div>
+    <div class="d-table-cell border border-black text-center w-7-5">AS</div>
+    <div class="d-table-cell border border-black text-center w-8">AR</div>
+    <div class="d-table-cell border border-black text-center w-8">Str</div>
+    <div class="d-table-cell border border-black text-center w-7-5">Def</div>
+    <div class="d-table-cell border border-black text-center w-7-5">Dex</div>
+    <div class="d-table-cell border border-black text-center w-8">Vit</div>
+    <div class="d-table-cell border border-black text-center w-8">WS</div>
+    <div class="d-table-cell border border-black text-center w-7-5">SA</div>
+    <div class="d-table-cell border border-black text-center w-7-5">VoH</div>
+    <div class="d-table-cell border border-black text-center w-8">DR</div>
+    <div class="d-table-cell border border-black text-center w-7-5">XPG</div>
+  </div>
+</div>

--- a/templates/simulator/itemModal.phtml
+++ b/templates/simulator/itemModal.phtml
@@ -99,7 +99,7 @@
                       </div>
                       <div class="d-table-cell align-top">
                         <div class="pl-1">
-                          <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a><a href="javascript:void(0);" target="_blank" class="item-link text-light pl-5"><i class="fas fa-external-link-alt"></i></a>
+                          <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a><a href="javascript:void(0);" target="_blank" class="item-link text-light ml-5"><i class="fas fa-external-link-alt"></i></a>
                         </div>
                         <div class="d-table w-100 small table-item-attrs">
                           <?= $this->fetch('simulator/itemStatsRow.phtml') ?>

--- a/templates/simulator/itemModal.phtml
+++ b/templates/simulator/itemModal.phtml
@@ -1,0 +1,130 @@
+<div class="modal fade" id="modal-items" tabindex="-1" role="dialog" aria-labelledby="modal-itemsTitle" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content bg-darkgreen">
+      <div class="modal-header">
+        <h4 class="modal-title" id="modal-itemsTitle">Select Item</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true" class="button-close-white">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body overflow-auto">
+        <div>
+          <a href="#collapse-search" class="lemonchiffon" data-toggle="collapse" aria-expanded="true" aria-controls="collapseExample"><i class="fas fa-search"></i>Search</a>
+        </div>
+        <div class="collapse show" id="collapse-search">
+          <div class="card mb-2 bg-darkblue">
+            <div class="card-body p-2">
+              <div class="form-check form-check-inline">
+                <input id="search-rarity-common" class="form-check-input" type="checkbox" value="true" />
+                <label class="form-check-label small" for="search-rarity-common">Common</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input id="search-rarity-rare" class="form-check-input" type="checkbox" value="true" />
+                <label class="form-check-label small rare" for="search-rarity-rare">Rare</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input id="search-rarity-artifact" class="form-check-input" type="checkbox" value="true" />
+                <label class="form-check-label small artifact" for="search-rarity-artifact">Artifact</label>
+              </div>
+              <div class="text-right">
+                <a href="javascript:void(0);" class="lemonchiffon" id="link-search-submit" data-item-slot=""><i class="far fa-check-circle"></i>Submit</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <table id="table-items" class="table-dark table-striped w-100 small mt-2" style="min-width: 420px;">
+          <thead>
+            <tr>
+              <td>
+                <div class="d-table w-100">
+                  <div class="d-table-row">
+                    <div class="d-table-cell text-center align-middle" style="width: 32px;">
+                      <a href="javascript:void(0);" class="thead-sort item-skill" data-attr="Skill"><i class="fas fa-exclamation-circle"></i></a>
+                    </div>
+                    <div class="d-table-cell">
+                      <div class="d-table w-100 small table-item-attrs">
+                        <div class="d-table-row">
+                          <div class="d-table-cell border border-black text-center w-15 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AD">AD</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AS">AS</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AR">AR</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Str">Str</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Def">Def</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Dex">Dex</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Vit">Vit</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="WS">WS</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="SA">SA</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="VoH">VoH</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="DR">DR</a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="XPG">XPG</a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            <template id="modal-item-row">
+              <tr>
+                <td>
+                  <div class="d-table w-100">
+                    <div class="d-table-row">
+                      <div class="d-table-cell align-middle" style="width: 32px;">
+                        <a href="javascript:void(0);" class="item-img"></a>
+                      </div>
+                      <div class="d-table-cell align-top">
+                        <div class="pl-1">
+                          <a href="javascript:void(0);" class="item-name"></a><a href="javascript:void(0);" class="item-skill d-none" data-toggle="tooltip" data-placement="top" title=""><i class="fas fa-exclamation-circle"></i></a><a href="javascript:void(0);" target="_blank" class="item-link text-light pl-5"><i class="fas fa-external-link-alt"></i></a>
+                        </div>
+                        <div class="d-table w-100 small table-item-attrs">
+                          <?= $this->fetch('simulator/itemStatsRow.phtml') ?>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </template>
+            <template id="modal-label-row">
+              <tr>
+                <td style="padding-left: 33px;">
+                  <?= $this->fetch('simulator/itemAttrsRow.phtml') ?>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
+        <div class="d-flex justify-content-center mt-3" id="scroll-loading">
+          <div class="spinner-border text-lignt" role="status">
+            <span class="sr-only">Loading...</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/simulator/itemStatsRow.phtml
+++ b/templates/simulator/itemStatsRow.phtml
@@ -1,0 +1,19 @@
+<div class="d-table-row">
+  <div class="d-table-cell border border-black text-right w-15">
+    &nbsp;
+    <span class="attr attr-minad"></span>
+    <span class="wave">~</span>
+    <span class="attr attr-maxad"></span>
+  </div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-as"></div>
+  <div class="d-table-cell border border-black text-right w-8 attr attr-ar"></div>
+  <div class="d-table-cell border border-black text-right w-8 attr attr-str"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-def"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-dex"></div>
+  <div class="d-table-cell border border-black text-right w-8 attr attr-vit"></div>
+  <div class="d-table-cell border border-black text-right w-8 attr attr-ws"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-sa"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-voh"></div>
+  <div class="d-table-cell border border-black text-right w-8 attr attr-dr"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-xpg"></div>
+</div>

--- a/templates/simulator/saveModal.phtml
+++ b/templates/simulator/saveModal.phtml
@@ -1,0 +1,138 @@
+<div class="modal fade" id="modal-save" tabindex="-1" role="dialog" aria-labelledby="modal-saveTitle" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content bg-darkgreen">
+      <div class="modal-header">
+        <h4 class="modal-title" id="modal-saveTitle">Save / Load</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true" class="button-close-white">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body overflow-auto">
+        <table id="table-current-build" class="table-dark table-striped w-100 mt-2">
+          <thead>
+            <tr>
+              <th class="pl-1">Current Build</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <div class="m-1">
+                  <input type="text" maxlength="32" name="text-save-name" placeholder="Build Name" class="form-control p-0 h-auto pr-2 text-save-name" />
+                </div>
+                <div class="d-table w-100">
+                  <div class="d-table-row">
+                    <div class="d-table-cell">
+                      <ul class="list-inline ml-1 mb-1">
+                        <?php for ($i = 1; $i <= 12; $i++) : ?>
+                          <li class="item-slot-<?= $i ?> list-inline-item mr-1 mt-1">
+                            <img class="item-icon" src="/img/common/other.png" alt="" />
+                          </li>
+                        <?php endfor; ?>
+                      </ul>
+                    </div>
+                    <div class="d-table-cell text-center align-middle w-25 font-large">
+                      <a href="javascript:void(0);" class="lemonchiffon link-save-current-build"><i class="fas fa-save"></i></a>
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table id="table-saved-build" class="table-dark table-striped w-100 mt-2">
+          <colgroup>
+            <col />
+            <col class="w-20" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th class="pl-1">Saved Build</th>
+              <th class="builds-count text-right pr-1 small">0&nbsp;/&nbsp;100</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td colspan="2">
+                <div class="small m-1 d-flex align-items-center">
+                  <img class="class-icon" src="/img/common/axe.png" /><span class="pl-1">Sample 1</span>
+                </div>
+                <div class="d-table w-100">
+                  <div class="d-table-row">
+                    <div class="d-table-cell">
+                      <ul class="list-inline ml-1 mb-1">
+                        <?php for ($i = 1; $i <= 12; $i++) : ?>
+                          <li class="item-slot-<?= $i ?> list-inline-item mr-1 mt-1">
+                            <img class="item-icon" src="/img/common/other.png" alt="" />
+                          </li>
+                        <?php endfor; ?>
+                      </ul>
+                    </div>
+                    <div class="d-table-cell text-center align-middle w-25 font-large">
+                      <ul class="list-inline mb-0">
+                        <li class="list-inline-item m-2">
+                          <a href="javascript:void(0);" class="lemonchiffon link-load"><i class="fas fa-download"></i></a>
+                        </li>
+                        <li class="list-inline-item mr-2 mt-1">
+                          <div class="dropdown">
+                            <a href="#" class="lemonchiffon link-load dropdown-toggle" role="button" id="dropdownMenuLink1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-ellipsis-h"></i></a>
+                            <div class="dropdown-menu" aria-labelledby="dropdownMenuLink1">
+                              <a href="javascript:void(0);" class="text-danger dropdown-item text-decoration-none"><i class="fas fa-trash-alt"></i>&nbsp;Delete</a>
+                              <div class="dropdown-divider"></div>
+                              <a href="javascript:void(0);" class="text-info dropdown-item text-decoration-none"><i class="fas fa-arrow-circle-up"></i>&nbsp;Move Up</a>
+                              <a href="javascript:void(0);" class="text-info dropdown-item text-decoration-none"><i class="fas fa-arrow-circle-down"></i>&nbsp;Move Down</a>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+            <template id="modal-build-row">
+              <tr>
+                <td colspan="2">
+                  <div class="small m-1 d-flex align-items-center">
+                    <img class="class-icon" src="/img/common/axe.png" /><span class="pl-1 build-name"></span>
+                  </div>
+                  <div class="d-table w-100">
+                    <div class="d-table-row">
+                      <div class="d-table-cell">
+                        <ul class="list-inline ml-1 mb-1">
+                          <?php for ($i = 1; $i <= 12; $i++) : ?>
+                            <li class="item-slot-<?= $i ?> list-inline-item mr-1 mt-1">
+                              <img class="item-icon" src="/img/common/other.png" alt="" />
+                            </li>
+                          <?php endfor; ?>
+                        </ul>
+                      </div>
+                      <div class="d-table-cell text-center align-middle w-25 font-large">
+                        <ul class="list-inline mb-0">
+                          <li class="list-inline-item m-2">
+                            <a href="javascript:void(0);" class="lemonchiffon link-load-build"><i class="fas fa-download"></i></a>
+                          </li>
+                          <li class="list-inline-item mr-2 mt-1">
+                            <div class="dropdown">
+                              <a href="#" class="lemonchiffon link-build-option dropdown-toggle" role="button" id="dropdownMenuLink0" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-ellipsis-h"></i></a>
+                              <div class="dropdown-menu" aria-labelledby="dropdownMenuLink0">
+                                <a href="javascript:void(0);" class="link-move-up-build text-info dropdown-item text-decoration-none"><i class="fas fa-arrow-circle-up"></i>&nbsp;Move Up</a>
+                                <a href="javascript:void(0);" class="link-move-down-build text-info dropdown-item text-decoration-none"><i class="fas fa-arrow-circle-down"></i>&nbsp;Move Down</a>
+                                <div class="dropdown-divider"></div>
+                                <a href="javascript:void(0);" class="link-delete-build text-danger dropdown-item text-decoration-none"><i class="fas fa-trash-alt"></i>&nbsp;Delete</a>
+                              </div>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# 新機能 : ビルド保存

- Save / Loadリンクを押すことで、ビルド保存画面を開く
- シミュレータで表示しているビルドに名前をつけてブラウザのlocal storageに保存できる
- 保存できるビルドの上限は100件
  - ビルドの保存件数が上限に達した場合、件数を黄色表記にし保存ボタンを非表示にする
- ビルドの名前は最大32文字
- 保存したビルドの一覧を表示できる
- ビルドの保存データには、ビルドの名前、クラス、装備アイテムの画像、読み込み用のpathが含まれる
- ビルド読み込みボタンを押すことで、保存したビルドを読み込む
- ビルドオプションボタンを押すことで、並び替えボタン、削除ボタンを表示する
- 上に移動ボタンは一番上のビルドで押した場合には機能しない
- 下に移動ボタンは一番下のビルドで押した場合には機能しない
- 削除ボタンを押すと、ビルドをlocal storageから削除する
- 保存情報の変更時には必ず一覧を再表示する
- 編集の競合防止のため、保存情報の変更時に別タブでビルド保存画面をすでに開いている場合は自動で閉じる

# 内部処理の改善

- シミュレータ画面のテンプレートを編集しやすいよう分割
- 流用可能な箇所は別テンプレートに切り出して流用