### PR TITLE
スタッツの説明ツールチップを追加

### DIFF
--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -307,4 +307,6 @@ $(function () {
     $("#creature-" + location.pathname.split('/')[2]).click();
   }
 
+  $("#tooltip-creature-stats-description").tooltip();
+
 });

--- a/public/js/item.js
+++ b/public/js/item.js
@@ -238,4 +238,6 @@ $(function () {
     $("#" + location.pathname.split('/')[4]).click();
   }
 
+  $("#tooltip-class-stats-description").tooltip();
+
 });

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -878,4 +878,7 @@ $(function () {
     $.LoadingOverlay("hide", true);
   }
 
+  // スタッツ略称説明のツールチップ
+  $("#tooltip-short-stats-description").tooltip();
+
 });

--- a/src/classes/controller/CreaturesController.php
+++ b/src/classes/controller/CreaturesController.php
@@ -19,7 +19,7 @@ class CreaturesController extends Controller
     public function index(Request $request, Response $response, array $args)
     {
         $this->title = 'クリーチャーデータ';
-        $this->scripts[] = '/js/creature.js?id=00078';
+        $this->scripts[] = '/js/creature.js?id=00080';
 
         try {
             $this->db->beginTransaction();

--- a/src/classes/controller/ItemsController.php
+++ b/src/classes/controller/ItemsController.php
@@ -45,7 +45,7 @@ class ItemsController extends Controller
     public function rareItem(Request $request, Response $response, array $args)
     {
         $this->title = ucfirst($args['itemClassName']) . ' レアアイテム';
-        $this->scripts[] = '/js/item.js?id=00075';
+        $this->scripts[] = '/js/item.js?id=00080';
 
         try {
             $this->db->beginTransaction();

--- a/src/classes/controller/ItemsController.php
+++ b/src/classes/controller/ItemsController.php
@@ -76,7 +76,7 @@ class ItemsController extends Controller
     public function commonItem(Request $request, Response $response, array $args)
     {
         $this->title = ucfirst($args['itemClassName']) . ' ノーマルアイテム';
-        $this->scripts[] = '/js/item.js?id=00075';
+        $this->scripts[] = '/js/item.js?id=00080';
 
         try {
             $this->db->beginTransaction();

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -23,7 +23,7 @@ class SimulatorController extends Controller
     public function index(Request $request, Response $response)
     {
         $this->title = 'シミュレータ';
-        $this->scripts[] = '/js/simulator.js?id=00077';
+        $this->scripts[] = '/js/simulator.js?id=00080';
         $item = new ItemModel($this->db, $this->logger);
         $getParam = $request->getQueryParams();
         $charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';

--- a/templates/common/tooltipClassStatsDescription.phtml
+++ b/templates/common/tooltipClassStatsDescription.phtml
@@ -1,0 +1,6 @@
+<div class='text-left text-light'>
+  <div>クラス別スタッツの表記</div>
+  <div>A&nbsp;:&nbsp;アックスマスター</div>
+  <div>S&nbsp;:&nbsp;ソードマスター</div>
+  <div>D&nbsp;:&nbsp;ダガーマスター</div>
+</div>

--- a/templates/common/tooltipCreatureStatsDescription.phtml
+++ b/templates/common/tooltipCreatureStatsDescription.phtml
@@ -1,0 +1,13 @@
+<div class='text-left text-light'>
+  <div>スタッツの省略表記</div>
+  <div>AD&nbsp;:&nbsp;攻撃力</div>
+  <div>AS&nbsp;:&nbsp;攻撃速度</div>
+  <div>Str&nbsp;:&nbsp;筋力</div>
+  <div>Def&nbsp;:&nbsp;防御力</div>
+  <div>Dex&nbsp;:&nbsp;技量</div>
+  <div>Vit&nbsp;:&nbsp;生命力</div>
+  <div>WS&nbsp;:&nbsp;移動速度</div>
+  <div>VoH&nbsp;:&nbsp;生命力吸収</div>
+  <div>DR&nbsp;:&nbsp;ダメージ反射</div>
+  <div>XP&nbsp;:&nbsp;EXP</div>
+</div>

--- a/templates/common/tooltipShortStatsDescription.phtml
+++ b/templates/common/tooltipShortStatsDescription.phtml
@@ -1,0 +1,15 @@
+<div class='text-left text-light'>
+  <div>スタッツの省略表記</div>
+  <div>AD&nbsp;:&nbsp;攻撃力</div>
+  <div>AS&nbsp;:&nbsp;攻撃速度</div>
+  <div>AR&nbsp;:&nbsp;攻撃範囲</div>
+  <div>Str&nbsp;:&nbsp;筋力</div>
+  <div>Def&nbsp;:&nbsp;防御力</div>
+  <div>Dex&nbsp;:&nbsp;技量</div>
+  <div>Vit&nbsp;:&nbsp;生命力</div>
+  <div>WS&nbsp;:&nbsp;移動速度</div>
+  <div>SA&nbsp;:&nbsp;スペシャルアタック</div>
+  <div>VoH&nbsp;:&nbsp;生命力吸収</div>
+  <div>DR&nbsp;:&nbsp;ダメージ反射</div>
+  <div>XPG&nbsp;:&nbsp;EXP取得</div>
+</div>

--- a/templates/creatures/index.phtml
+++ b/templates/creatures/index.phtml
@@ -225,6 +225,9 @@
 <div class="d-inline-block pl-4">
   <input type="checkbox" id="check-tb" class="form-check-input" value="true" /><label for="check-tb">TB Creature</label>
 </div>
+<div>
+  <a href=" javascript:void(0);" id="tooltip-creature-stats-description" class="text-light" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipCreatureStatsDescription.phtml') ?>"><i class="fas fa-question-circle"></i></a>
+</div>
 <table class="table-dark table-striped table-hover w-100 small" id="creature-list">
   <tbody>
     <template id="list-label-row">

--- a/templates/items/common.phtml
+++ b/templates/items/common.phtml
@@ -10,6 +10,9 @@
 <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
 
 <h2 class="common mt-3"><?= $base_item['name_en'] ?></h2>
+<div>
+  <a href="javascript:void(0);" id="tooltip-class-stats-description" class="text-light" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipClassStatsDescription.phtml') ?>"><i class="fas fa-question-circle"></i></a>
+</div>
 <?php if (empty($items)) : ?>
   <h3>No Data</h3>
 <?php endif; ?>

--- a/templates/items/rare.phtml
+++ b/templates/items/rare.phtml
@@ -9,7 +9,10 @@
 
 <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
 
-<h2 class="rare mt-3"><?= $item_class ?> Rare</h2>
+<h2 class="rare mt-3"><?= $item_class ?>&nbsp;Rare</h2>
+<div>
+  <a href="javascript:void(0);" id="tooltip-class-stats-description" class="text-light" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipClassStatsDescription.phtml') ?>"><i class="fas fa-question-circle"></i></a>
+</div>
 <?php if (empty($items['rare'])) : ?>
   <h3>No Data</h3>
 <?php endif; ?>
@@ -19,7 +22,7 @@
 
 <?= $this->fetch('adsense.phtml', ['google' => $header['google']]) ?>
 
-<h2 class="artifact mt-3"><?= $item_class ?> Artifact</h2>
+<h2 class="artifact mt-3"><?= $item_class ?>&nbsp;Artifact</h2>
 <?php if (empty($items['artifact'])) : ?>
   <h3>No Data</h3>
 <?php endif; ?>

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -186,7 +186,7 @@
         <tbody>
           <tr>
             <td style="padding-left: 33px;">
-              <span style="margin-left: -32px;">Equipment Items</span>
+              <span style="margin-left: -32px;">Equipment Items</span>&nbsp;<a href="javascript:void(0);" id="tooltip-short-stats-description" class="text-light" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipShortStatsDescription.phtml') ?>"><i class="fas fa-question-circle"></i></a>
               <?= $this->fetch('simulator/itemAttrsRow.phtml') ?>
             </td>
           </tr>


### PR DESCRIPTION
# 説明文言追加

- アイテムデータにクラス別スタッツの説明ツールチップを追加
- クリーチャーデータにスタッツ略称の説明ツールチップを追加
- シミュレータにスタッツ略称の説明ツールチップを追加
- 現状は日本語での表記（多言語対応予定）