### PR TITLE
更新情報の多言語対応

### DIFF
--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,5 +1,5 @@
 -- Project Name : Uruluk
--- Date/Time    : 2024/03/18 0:16:48
+-- Date/Time    : 2024/03/18 4:06:59
 -- Author       : candl
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
@@ -437,7 +437,9 @@ drop table if exists `news` cascade;
 create table `news` (
   `post_date` DATETIME not null comment '投稿日時'
   , `subject` VARCHAR(256) comment '件名'
+  , `subject_en` VARCHAR(256) comment '件名(英語)'
   , `content` TEXT comment '本文'
+  , `content_en` TEXT comment '本文(英語)'
   , constraint `news_PKC` primary key (`post_date`)
 ) comment 'お知らせ' ;
 

--- a/src/classes/model/NewsModel.php
+++ b/src/classes/model/NewsModel.php
@@ -27,7 +27,9 @@ class NewsModel extends Model
                 SQL_CALC_FOUND_ROWS
                 post_date
                 , subject
+                , subject_en
                 , content
+                , content_en
             FROM
                 news
             ORDER BY
@@ -42,10 +44,19 @@ class NewsModel extends Model
         $stmt->execute();
         $newsList = [];
         while ($result = $stmt->fetch()) {
+            switch ($this->i18n->getLangCode()) {
+                case 'en':
+                    $subject = empty($result['subject_en']) ? $result['subject'] : $result['subject_en'];
+                    $content = empty($result['content_en']) ? $result['content'] : $result['content_en'];
+                    break;
+                default:
+                    $subject = $result['subject'];
+                    $content = $result['content'];
+            }
             $newsList[] = [
                 'post_date' => $result['post_date'],
-                'subject' => $result['subject'],
-                'content' => $result['content']
+                'subject' => $subject,
+                'content' => $content
             ];
         }
         $sql = <<<SQL

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -11,7 +11,7 @@
       <h5 class="card-header border-secondary"><?= $l->s('index.news_and_update') ?></h5>
       <?php foreach ($newsList as $news) : ?>
         <div class="card-body border-bottom border-secondary">
-          <h5 class="card-title"><?= $news['post_date'] ?></h5>
+          <h5 class="card-title"><?= $news['post_date'] ?><?= $l->getLangCode() != 'ja' ? '&nbsp;(JST)' : '' ?></h5>
           <div class="card-title"><?= $news['subject'] ?></div>
           <p class="mb-0"><?= nl2br($news['content']) ?></p>
         </div>


### PR DESCRIPTION
# 更新情報を多言語対応

- 翻訳ファイル、テーブルは用いず、newsテーブルに英語のタイトル、本文の項目を追加
- 対応する言語の文言が設定されていない場合、日本語で表示される