### PR TITLE
中国語でのアクセス時に文言が消える不具合を修正

### DIFF
--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -38,9 +38,10 @@ return function (App $app) {
             $is_wildcard = isset($locale['language']) && $locale['language'] === '*';
             if (empty($locale['language']) && !$is_wildcard) return null;
             if ($is_wildcard || $locale['language'] === 'zh') {
-                if (!empty($locale['region']) && $locale['region'] == 'TW') return 'zh_tw';
-                if (!empty($locale['script']) && $locale['script'] == 'Hant') return 'zh_tw';
-                if ($locale['language'] === 'zh') return 'zh_cn';
+                // TODO 中国語対応実施時にコメントアウトを外す
+                // if (!empty($locale['region']) && $locale['region'] == 'TW') return 'zh_tw';
+                // if (!empty($locale['script']) && $locale['script'] == 'Hant') return 'zh_tw';
+                // if ($locale['language'] === 'zh') return 'zh_cn';
             }
             if (in_array($locale['language'], $knownLanguages)) return $locale['language'];
             return null;


### PR DESCRIPTION
# 不具合修正 : 中国語でのアクセス時に文言が消える不具合を修正

- 中国語の種類を検知する処理をコメントアウト
- 今後中国語の対応を行う際にコメントアウトを外す