### PR TITLE
新しいスタッツ「スペシャルアタックダメージ」を追加

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -66,12 +66,20 @@ li.charge-type-skill>input.form-check-input {
   border-color: #263337 !important;
 }
 
+.w-7 {
+  width: 7% !important;
+}
+
 .w-7-5 {
   width: 7.5% !important;
 }
 
 .w-8 {
   width: 8% !important;
+}
+
+.w-13 {
+  width: 13% !important;
 }
 
 .w-14 {

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -12,6 +12,9 @@ $(function () {
     "vit",
     "ws",
     "sa",
+    "sad",
+    "minsad",
+    "maxsad",
     "voh",
     "dr",
     "xpg"
@@ -33,6 +36,9 @@ $(function () {
       "vit": 100,
       "ws": 56.55,
       "sa": 30,
+      "sad": 150,
+      "minsad": 0,
+      "maxsad": 0,
       "voh": 0,
       "dr": 0,
       "xpg": 0
@@ -48,6 +54,9 @@ $(function () {
       "vit": 120,
       "ws": 53.55,
       "sa": 30,
+      "sad": 300,
+      "minsad": 0,
+      "maxsad": 0,
       "voh": 0,
       "dr": 0,
       "xpg": 0
@@ -63,6 +72,9 @@ $(function () {
       "vit": 80,
       "ws": 59.55,
       "sa": 30,
+      "sad": 300,
+      "minsad": 0,
+      "maxsad": 0,
       "voh": 0,
       "dr": 0,
       "xpg": 0
@@ -241,12 +253,16 @@ $(function () {
       attrs.maxad += attrs.str;
     }
 
+    // SADを計算
+    attrs.minsad = attrs.minad * attrs.sad / 100;
+    attrs.maxsad = attrs.maxad * attrs.sad / 100;
+
     // 画面に反映
     attrNames.forEach(attrName => {
       if (attrs[attrName] < 0) {
         attrs[attrName] = 0;
       }
-      $(".table-attributes .attr-" + attrName).text(Math.round(attrs[attrName]));
+      $(".table-attributes .attr-" + attrName).text(Math.round(attrs[attrName] - 0.0000005));
 
       // No Delay判定
       if (attrName == "sa") {

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -23,7 +23,7 @@ class SimulatorController extends Controller
     public function index(Request $request, Response $response)
     {
         $this->title = 'シミュレータ';
-        $this->scripts[] = '/js/simulator.js?id=00080';
+        $this->scripts[] = '/js/simulator.js?id=00084';
         $item = new ItemModel($this->db, $this->logger, $this->i18n);
         $getParam = $request->getQueryParams();
         $charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';

--- a/src/resources/en.yaml
+++ b/src/resources/en.yaml
@@ -41,6 +41,8 @@ stats:
   ws_full: 'Walk Speed'
   sa: 'SA'
   sa_full: 'Special Attack'
+  sad: 'SAD'
+  sad_full: 'Special Attack Damage'
   voh: 'VoH'
   voh_full: 'Vitality on Hit'
   dr: 'DR'

--- a/src/resources/ja.yaml
+++ b/src/resources/ja.yaml
@@ -41,6 +41,8 @@ stats:
   ws_full: '移動速度'
   sa: 'SA'
   sa_full: 'スペシャルアタック'
+  sad: 'SAD'
+  sad_full: 'スペシャルアタックダメージ'
   voh: 'VoH'
   voh_full: '生命力吸収'
   dr: 'DR'

--- a/templates/header.phtml
+++ b/templates/header.phtml
@@ -21,7 +21,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-  <link rel="stylesheet" href="/css/main.css?id=00081">
+  <link rel="stylesheet" href="/css/main.css?id=00084">
   <link rel="stylesheet" href="/lib/photoswipe/photoswipe.css">
   <link rel="stylesheet" href="/lib/photoswipe/default-skin/default-skin.css">
   <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>

--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -88,6 +88,13 @@
             </td>
           </tr>
           <tr>
+            <td colspan="2" class="align-top"><?= $l->s('stats.sad_full') ?></td>
+            <td class="text-right attr-value">
+              <div><span class="attr-sad">150</span><?= $l->s('common.unit_percent') ?></div>
+              <div><span class="attr-minsad">0</span>～<span class="attr-maxsad">0</span></div>
+            </td>
+          </tr>
+          <tr>
             <td colspan="2"><?= $l->s('stats.voh_full') ?></td>
             <td class="text-right attr-value"><span class="attr-voh">0</span><?= $l->s('common.unit_percent') ?></td>
           </tr>
@@ -183,7 +190,7 @@
   </div>
   <div class="row">
     <div class="col-12 px-1 overflow-auto">
-      <table class="table-item-slot table-dark table-striped w-100 small" style="min-width: 420px;">
+      <table class="table-item-slot table-dark table-striped w-100 small" style="min-width: 460px;">
         <tbody>
           <tr>
             <td style="padding-left: 33px;">

--- a/templates/simulator/itemAttrsRow.phtml
+++ b/templates/simulator/itemAttrsRow.phtml
@@ -1,16 +1,17 @@
 <div class="d-table w-100 small table-item-attrs">
   <div class="d-table-row small">
-    <div class="d-table-cell border border-black text-center w-15"><?= $l->s('stats.ad') ?></div>
-    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.as') ?></div>
-    <div class="d-table-cell border border-black text-center w-8"><?= $l->s('stats.ar') ?></div>
-    <div class="d-table-cell border border-black text-center w-8"><?= $l->s('stats.str') ?></div>
-    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.def') ?></div>
-    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.dex') ?></div>
-    <div class="d-table-cell border border-black text-center w-8"><?= $l->s('stats.vit') ?></div>
-    <div class="d-table-cell border border-black text-center w-8"><?= $l->s('stats.ws') ?></div>
-    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.sa') ?></div>
-    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.voh') ?></div>
-    <div class="d-table-cell border border-black text-center w-8"><?= $l->s('stats.dr') ?></div>
-    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.xpg') ?></div>
+    <div class="d-table-cell border border-black text-center w-13"><?= $l->s('stats.ad') ?></div>
+    <div class="d-table-cell border border-black text-center w-7"><?= $l->s('stats.as') ?></div>
+    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.ar') ?></div>
+    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.str') ?></div>
+    <div class="d-table-cell border border-black text-center w-7"><?= $l->s('stats.def') ?></div>
+    <div class="d-table-cell border border-black text-center w-7"><?= $l->s('stats.dex') ?></div>
+    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.vit') ?></div>
+    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.ws') ?></div>
+    <div class="d-table-cell border border-black text-center w-7"><?= $l->s('stats.sa') ?></div>
+    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.sad') ?></div>
+    <div class="d-table-cell border border-black text-center w-7"><?= $l->s('stats.voh') ?></div>
+    <div class="d-table-cell border border-black text-center w-7-5"><?= $l->s('stats.dr') ?></div>
+    <div class="d-table-cell border border-black text-center w-7"><?= $l->s('stats.xpg') ?></div>
   </div>
 </div>

--- a/templates/simulator/itemModal.phtml
+++ b/templates/simulator/itemModal.phtml
@@ -32,7 +32,7 @@
             </div>
           </div>
         </div>
-        <table id="table-items" class="table-dark table-striped w-100 small mt-2" style="min-width: 420px;">
+        <table id="table-items" class="table-dark table-striped w-100 small mt-2" style="min-width: 460px;">
           <thead>
             <tr>
               <td>
@@ -44,40 +44,43 @@
                     <div class="d-table-cell">
                       <div class="d-table w-100 small table-item-attrs">
                         <div class="d-table-row">
-                          <div class="d-table-cell border border-black text-center w-15 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-13 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AD"><?= $l->s('stats.ad') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AS"><?= $l->s('stats.as') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="AR"><?= $l->s('stats.ar') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Str"><?= $l->s('stats.str') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Def"><?= $l->s('stats.def') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Dex"><?= $l->s('stats.dex') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="Vit"><?= $l->s('stats.vit') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="WS"><?= $l->s('stats.ws') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="SA"><?= $l->s('stats.sa') ?></a>
                           </div>
                           <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                            <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="SAD"><?= $l->s('stats.sad') ?></a>
+                          </div>
+                          <div class="d-table-cell border border-black text-center w-7 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="VoH"><?= $l->s('stats.voh') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-8 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="DR"><?= $l->s('stats.dr') ?></a>
                           </div>
-                          <div class="d-table-cell border border-black text-center w-7-5 align-middle py-1">
+                          <div class="d-table-cell border border-black text-center w-7 align-middle py-1">
                             <a href="javascript:void(0);" class="thead-sort lemonchiffon" data-attr="XPG"><?= $l->s('stats.xpg') ?></a>
                           </div>
                         </div>

--- a/templates/simulator/itemStatsRow.phtml
+++ b/templates/simulator/itemStatsRow.phtml
@@ -1,19 +1,20 @@
 <div class="d-table-row">
-  <div class="d-table-cell border border-black text-right w-15">
+  <div class="d-table-cell border border-black text-right w-13">
     &nbsp;
     <span class="attr attr-minad"></span>
     <span class="wave">~</span>
     <span class="attr attr-maxad"></span>
   </div>
-  <div class="d-table-cell border border-black text-right w-7-5 attr attr-as"></div>
-  <div class="d-table-cell border border-black text-right w-8 attr attr-ar"></div>
-  <div class="d-table-cell border border-black text-right w-8 attr attr-str"></div>
-  <div class="d-table-cell border border-black text-right w-7-5 attr attr-def"></div>
-  <div class="d-table-cell border border-black text-right w-7-5 attr attr-dex"></div>
-  <div class="d-table-cell border border-black text-right w-8 attr attr-vit"></div>
-  <div class="d-table-cell border border-black text-right w-8 attr attr-ws"></div>
-  <div class="d-table-cell border border-black text-right w-7-5 attr attr-sa"></div>
-  <div class="d-table-cell border border-black text-right w-7-5 attr attr-voh"></div>
-  <div class="d-table-cell border border-black text-right w-8 attr attr-dr"></div>
-  <div class="d-table-cell border border-black text-right w-7-5 attr attr-xpg"></div>
+  <div class="d-table-cell border border-black text-right w-7 attr attr-as"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-ar"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-str"></div>
+  <div class="d-table-cell border border-black text-right w-7 attr attr-def"></div>
+  <div class="d-table-cell border border-black text-right w-7 attr attr-dex"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-vit"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-ws"></div>
+  <div class="d-table-cell border border-black text-right w-7 attr attr-sa"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-sad"></div>
+  <div class="d-table-cell border border-black text-right w-7 attr attr-voh"></div>
+  <div class="d-table-cell border border-black text-right w-7-5 attr attr-dr"></div>
+  <div class="d-table-cell border border-black text-right w-7 attr attr-xpg"></div>
 </div>


### PR DESCRIPTION
# 新しいスタッツ「スペシャルアタックダメージ」を追加

- シミュレータにスペシャルアタックダメージの項目を追加
- スタッツ補正としての倍率と実際のダメージ値の両方を記載
- スタッツの文言(英語、日本語)を追加
- シミュレータでの端数の切り上げ処理をゲーム内と同等のものに修正