### PR TITLE
シミュレータのテーブルの色を修正

### DIFF
--- a/templates/simulator/index.phtml
+++ b/templates/simulator/index.phtml
@@ -17,6 +17,9 @@
           <col />
         </colgroup>
         <tbody>
+          <tr class="d-none">
+            <td colspan="3"></td>
+          </tr>
           <tr>
             <td colspan="3">
               <div class="w-100 mb-0">


### PR DESCRIPTION
- 行を追加したことで同色が連続するのを解消