### PR TITLE
シミュレータで保存ダイアログ表示時にスクリプトエラーが発生する不具合を修正

### DIFF
--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -735,7 +735,7 @@ $(function () {
     });
 
     slotItems.forEach((item, index) => {
-      if (item.item_id) {
+      if (item && item.item_id) {
         $("#table-current-build li.item-slot-" + index + " img")
           .attr("src", "/img/item/" + item.image_name)
           .attr("alt", item.name);
@@ -777,7 +777,7 @@ $(function () {
     const buildName = $("#modal-save input.text-save-name").val();
     const images = [];
     slotItems.forEach((item) => {
-      if (item.item_id) {
+      if (item && item.item_id) {
         images.push(item.image_name);
       } else {
         images.push(null);

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -23,7 +23,7 @@ class SimulatorController extends Controller
     public function index(Request $request, Response $response)
     {
         $this->title = 'シミュレータ';
-        $this->scripts[] = '/js/simulator.js?id=00084';
+        $this->scripts[] = '/js/simulator.js?id=00087';
         $item = new ItemModel($this->db, $this->logger, $this->i18n);
         $getParam = $request->getQueryParams();
         $charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';


### PR DESCRIPTION
# 不具合修正：シミュレータで保存ダイアログ表示ができないことがある

- 初期表示以外で装備スロットが空になっている場合にエラーが発生する
- 初期表示時と操作による空セット処理が異なりundefinedを考慮していない問題
- 保存ボタン押下時にも同様の問題があるため対処