### PR TITLE
ページタイトルが翻訳されていないのを修正

### DIFF
--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -132,7 +132,7 @@ $(function () {
 
   $("#modal-creature").on('hide.bs.modal', function () {
     if (!autoTransition && location.pathname.split('/').length != 2) {
-      history.pushState(null, null, '/creatures');
+      history.pushState(null, document.title, '/creatures');
     }
     autoTransition = false;
   });
@@ -278,7 +278,7 @@ $(function () {
         floorList.find("a.floor-description").tooltip();
 
         if (!at && location.pathname.split('/').length != 3) {
-          history.pushState(null, null, '/creatures/' + creatureId);
+          history.pushState(null, document.title, '/creatures/' + creatureId);
         }
 
         $("select.tb-phase").trigger('change');

--- a/public/js/item.js
+++ b/public/js/item.js
@@ -30,7 +30,7 @@ $(function () {
 
   $("#modal-item").on('hide.bs.modal', function () {
     if (!autoTransition && location.pathname.split('/').length != 4) {
-      history.pushState(null, null,
+      history.pushState(null, document.title,
         '/items/' + location.pathname.split('/')[2]
         + '/' + location.pathname.split('/')[3]);
     }
@@ -223,7 +223,7 @@ $(function () {
       });
 
       if (!at && location.pathname.split('/').length != 5) {
-        history.pushState(null, null,
+        history.pushState(null, document.title,
           '/items/' + location.pathname.split('/')[2]
           + '/' + location.pathname.split('/')[3] + '/' + itemId);
       }

--- a/src/classes/controller/CreaturesController.php
+++ b/src/classes/controller/CreaturesController.php
@@ -18,8 +18,8 @@ class CreaturesController extends Controller
 
     public function index(Request $request, Response $response, array $args)
     {
-        $this->title = 'クリーチャーデータ';
-        $this->scripts[] = '/js/creature.js?id=00081';
+        $this->title = $this->i18n->s('page_title.creatures');
+        $this->scripts[] = '/js/creature.js?id=00088';
 
         try {
             $this->db->beginTransaction();

--- a/src/classes/controller/FloorsController.php
+++ b/src/classes/controller/FloorsController.php
@@ -20,7 +20,7 @@ class FloorsController extends Controller
 
     public function index(Request $request, Response $response, array $args)
     {
-        $this->title = 'フロアデータ';
+        $this->title = $this->i18n->s('page_title.floors');
 
         try {
             $this->db->beginTransaction();
@@ -45,7 +45,7 @@ class FloorsController extends Controller
 
     public function detail(Request $request, Response $response, array $args)
     {
-        $this->title = 'フロアデータ';
+        $this->title = $this->i18n->s('page_title.floors');
         $this->scripts[] = '/js/floor.js?id=00081';
         $this->scripts[] = '/lib/photoswipe/photoswipe.min.js?id=00041';
         $this->scripts[] = '/lib/photoswipe/photoswipe-ui-default.min.js?id=00041';

--- a/src/classes/controller/ItemsController.php
+++ b/src/classes/controller/ItemsController.php
@@ -21,7 +21,7 @@ class ItemsController extends Controller
 
     public function index(Request $request, Response $response)
     {
-        $this->title = 'アイテムデータ';
+        $this->title = $this->i18n->s('page_title.items');
 
         try {
             $this->db->beginTransaction();
@@ -45,8 +45,8 @@ class ItemsController extends Controller
 
     public function rareItem(Request $request, Response $response, array $args)
     {
-        $this->title = ucfirst($args['itemClassName']) . ' レアアイテム';
-        $this->scripts[] = '/js/item.js?id=00081';
+        $this->title = ucfirst($args['itemClassName']) . ' ' . $this->i18n->s('page_title.items_rare');
+        $this->scripts[] = '/js/item.js?id=00088';
 
         try {
             $this->db->beginTransaction();
@@ -77,8 +77,8 @@ class ItemsController extends Controller
 
     public function commonItem(Request $request, Response $response, array $args)
     {
-        $this->title = ucfirst($args['itemClassName']) . ' ノーマルアイテム';
-        $this->scripts[] = '/js/item.js?id=00081';
+        $this->title = ucfirst($args['itemClassName']) . ' ' . $this->i18n->s('page_title.items_common');
+        $this->scripts[] = '/js/item.js?id=00088';
 
         try {
             $this->db->beginTransaction();

--- a/src/classes/controller/NewsController.php
+++ b/src/classes/controller/NewsController.php
@@ -15,7 +15,7 @@ class NewsController extends Controller
 
     public function index(Request $request, Response $response)
     {
-        $this->title = '更新情報';
+        $this->title = $this->i18n->s('page_title.news');
         $getParam = $request->getQueryParams();
         $page = 0;
         if (isset($getParam['page']) && is_numeric($getParam['page'])) {

--- a/src/classes/controller/PrivacyPolicyController.php
+++ b/src/classes/controller/PrivacyPolicyController.php
@@ -16,7 +16,7 @@ class PrivacyPolicyController extends Controller
 
     public function index(Request $request, Response $response)
     {
-        $this->title = 'プライバシーポリシー';
+        $this->title = $this->i18n->s('page_title.privacy_policy');
 
         try {
             $this->db->beginTransaction();

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -22,7 +22,7 @@ class SimulatorController extends Controller
 
     public function index(Request $request, Response $response)
     {
-        $this->title = 'シミュレータ';
+        $this->title = $this->i18n->s('page_title.simulator');
         $this->scripts[] = '/js/simulator.js?id=00087';
         $item = new ItemModel($this->db, $this->logger, $this->i18n);
         $getParam = $request->getQueryParams();

--- a/src/classes/controller/TagController.php
+++ b/src/classes/controller/TagController.php
@@ -17,7 +17,7 @@ class TagController extends Controller
 
     public function index(Request $request, Response $response, array $args)
     {
-        $this->title = 'タグ';
+        $this->title = $this->i18n->s('page_title.tags');
 
         try {
             $this->db->beginTransaction();
@@ -51,7 +51,7 @@ class TagController extends Controller
 
             if ($detail == null) throw new NotFoundException($request, $response);
 
-            $this->title = 'タグ:' . $detail['tag_name'];
+            $this->title = $this->i18n->s('page_title.tags') . ' - ' . $detail['tag_name'];
 
             $args = [
                 'header' => $this->getHeaderInfo(),


### PR DESCRIPTION
# 不具合修正 : ページタイトルの翻訳適用

- ページタイトルを多言語対応化
- アイテム、クリーチャーの詳細ページのタイトルが未設定になる不具合を修正