### PR TITLE
更新情報を中国語(簡体字・繫體字)に対応

### DIFF
--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,5 +1,5 @@
 -- Project Name : Uruluk
--- Date/Time    : 2024/03/18 4:06:59
+-- Date/Time    : 2024/06/12 14:23:31
 -- Author       : candl
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
@@ -438,8 +438,12 @@ create table `news` (
   `post_date` DATETIME not null comment '投稿日時'
   , `subject` VARCHAR(256) comment '件名'
   , `subject_en` VARCHAR(256) comment '件名(英語)'
+  , `subject_zh_cn` VARCHAR(256) comment '件名(簡体中文)'
+  , `subject_zh_tw` VARCHAR(256) comment '件名(繫體中文)'
   , `content` TEXT comment '本文'
   , `content_en` TEXT comment '本文(英語)'
+  , `content_zh_cn` TEXT comment '本文(簡体中文)'
+  , `content_zh_tw` TEXT comment '本文(繫體中文)'
   , constraint `news_PKC` primary key (`post_date`)
 ) comment 'お知らせ' ;
 

--- a/src/classes/model/NewsModel.php
+++ b/src/classes/model/NewsModel.php
@@ -28,8 +28,12 @@ class NewsModel extends Model
                 post_date
                 , subject
                 , subject_en
+                , subject_zh_cn
+                , subject_zh_tw
                 , content
                 , content_en
+                , content_zh_cn
+                , content_zh_tw
             FROM
                 news
             ORDER BY
@@ -45,13 +49,25 @@ class NewsModel extends Model
         $newsList = [];
         while ($result = $stmt->fetch()) {
             switch ($this->i18n->getLangCode()) {
-                case 'en':
-                    $subject = empty($result['subject_en']) ? $result['subject'] : $result['subject_en'];
-                    $content = empty($result['content_en']) ? $result['content'] : $result['content_en'];
-                    break;
-                default:
+                case 'ja':
                     $subject = $result['subject'];
                     $content = $result['content'];
+                    break;
+                case 'zh-CN':
+                    $subject = $result['subject_zh_cn'];
+                    $content = $result['content_zh_cn'];
+                    break;
+                case 'zh-TW':
+                    $subject = $result['subject_zh_tw'];
+                    $content = $result['content_zh_tw'];
+                    break;
+                default:
+                    $subject = $result['subject_en'];
+                    $content = $result['content_en'];
+            }
+            if (empty($subject) || empty($content)) {
+                $subject = empty($result['subject_en']) ? $result['subject'] : $result['subject_en'];
+                $content = empty($result['content_en']) ? $result['content'] : $result['content_en'];
             }
             $newsList[] = [
                 'post_date' => $result['post_date'],


### PR DESCRIPTION
# 機能改修

- 更新情報の件名、内容を中国語(簡体字・繫體字)に対応
- 更新情報の表示言語の優先順位を 設定言語->英語->日本語 に変更