### PR TITLE
結界地フェーズ補正の攻撃速度の計算式を修正

### DIFF
--- a/public/js/creature.js
+++ b/public/js/creature.js
@@ -76,7 +76,8 @@ $(function () {
       return;
     }
     if (baseTagId == "#detail-as") {
-      base.text(Math.round(base.data("base-val") / (1 + boostVal * level / 100) - 0.0000005));
+      const boostedAS = Math.round(base.data("base-val") * (1 - boostVal * level / 100) - 0.0000005);
+      base.text(boostedAS > 0 ? boostedAS : 0);
     } else {
       base.text(Math.round(base.data("base-val") * (1 + boostVal * level / 100) - 0.0000005) + (isPercentage ? '%' : ''));
     }

--- a/src/classes/controller/CreaturesController.php
+++ b/src/classes/controller/CreaturesController.php
@@ -19,7 +19,7 @@ class CreaturesController extends Controller
     public function index(Request $request, Response $response, array $args)
     {
         $this->title = $this->i18n->s('page_title.creatures');
-        $this->scripts[] = '/js/creature.js?id=00088';
+        $this->scripts[] = '/js/creature.js?id=00090';
 
         try {
             $this->db->beginTransaction();


### PR DESCRIPTION
# 機能修正

- クリーチャーデータの攻撃速度の結界地フェーズ補正適用の計算式を修正
- 補正割合を100%から直接引く計算に変更
- フェーズ補正による攻撃速度の下限を0に設定