### PR TITLE
アイテム所持済みチェック機能を追加

### DIFF
--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,5 +1,5 @@
 -- Project Name : Uruluk
--- Date/Time    : 2024/06/12 14:23:31
+-- Date/Time    : 2024/07/20 2:47:22
 -- Author       : candl
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
@@ -305,6 +305,7 @@ create table `item` (
   , `base_item_id` INT comment 'ベースアイテムID'
   , `brand_id` INT comment 'ブランドID'
   , `class_flactuable` BIT(1) default 0 not null comment 'クラス変動'
+  , `class_flactuable_base_id` INT comment 'クラス変動ベースID'
   , `name_key` VARCHAR(128) comment '名称キー'
   , `name_en` VARCHAR(64) comment '名称(英語)'
   , `name_ja` VARCHAR(64) comment '名称(日本語)'
@@ -323,6 +324,7 @@ create table `item` (
   , `comment_ja` VARCHAR(64) comment 'コメント(日本語)'
   , `note` TEXT comment '説明'
   , `price` INT comment '売却価格'
+  , `storable_counrt` INT default 1 comment '倉庫保管数'
   , `image_name` VARCHAR(64) comment '画像名称'
   , `sort_key` VARCHAR(16) not null comment 'ソート順'
   , constraint `item_PKC` primary key (`item_id`)
@@ -398,7 +400,7 @@ drop table if exists `item_skill` cascade;
 create table `item_skill` (
   `skill_id` INT AUTO_INCREMENT comment 'アイテムスキルID'
   , `name` VARCHAR(64) not null comment 'スキル名'
-  , `trigger_type` ENUM('attack', 'kill', 'damage') not null comment 'トリガー種別'
+  , `trigger_type` ENUM('attack', 'kill', 'damage', 'sa') not null comment 'トリガー種別'
   , `kill_trigger_type` ENUM('any', 'dr', 'sa') comment '討伐トリガー種別'
   , `activation_rate` INT not null comment '発動率(%)'
   , `trigger_charge` INT not null comment 'トリガーチャージ'

--- a/database/ddl.sql
+++ b/database/ddl.sql
@@ -1,5 +1,5 @@
 -- Project Name : Uruluk
--- Date/Time    : 2024/07/20 2:47:22
+-- Date/Time    : 2024/07/20 3:21:50
 -- Author       : candl
 -- RDBMS Type   : MySQL
 -- Application  : A5:SQL Mk-2
@@ -324,7 +324,7 @@ create table `item` (
   , `comment_ja` VARCHAR(64) comment 'コメント(日本語)'
   , `note` TEXT comment '説明'
   , `price` INT comment '売却価格'
-  , `storable_counrt` INT default 1 comment '倉庫保管数'
+  , `storable_count` INT default 1 comment '倉庫保管数'
   , `image_name` VARCHAR(64) comment '画像名称'
   , `sort_key` VARCHAR(16) not null comment 'ソート順'
   , constraint `item_PKC` primary key (`item_id`)

--- a/public/js/item.js
+++ b/public/js/item.js
@@ -238,5 +238,6 @@ $(function () {
   }
 
   $("#tooltip-class-stats-description").tooltip();
+  $("#tooltip-obtained-items").tooltip();
 
 });

--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -907,4 +907,7 @@ $(function () {
   // スタッツ略称説明のツールチップ
   $("#tooltip-short-stats-description").tooltip();
 
+  // 所持済みアイテムのツールチップ
+  $("#tooltip-obtained-items").tooltip();
+
 });

--- a/src/classes/controller/ItemsController.php
+++ b/src/classes/controller/ItemsController.php
@@ -46,7 +46,7 @@ class ItemsController extends Controller
     public function rareItem(Request $request, Response $response, array $args)
     {
         $this->title = ucfirst($args['itemClassName']) . ' ' . $this->i18n->s('page_title.items_rare');
-        $this->scripts[] = '/js/item.js?id=00088';
+        $this->scripts[] = '/js/item.js?id=00092';
 
         try {
             $this->db->beginTransaction();
@@ -78,7 +78,7 @@ class ItemsController extends Controller
     public function commonItem(Request $request, Response $response, array $args)
     {
         $this->title = ucfirst($args['itemClassName']) . ' ' . $this->i18n->s('page_title.items_common');
-        $this->scripts[] = '/js/item.js?id=00088';
+        $this->scripts[] = '/js/item.js?id=00092';
 
         try {
             $this->db->beginTransaction();

--- a/src/classes/controller/SimulatorController.php
+++ b/src/classes/controller/SimulatorController.php
@@ -23,7 +23,7 @@ class SimulatorController extends Controller
     public function index(Request $request, Response $response)
     {
         $this->title = $this->i18n->s('page_title.simulator');
-        $this->scripts[] = '/js/simulator.js?id=00087';
+        $this->scripts[] = '/js/simulator.js?id=00092';
         $item = new ItemModel($this->db, $this->logger, $this->i18n);
         $getParam = $request->getQueryParams();
         $charClass = array_key_exists('c', $getParam) && array_key_exists($getParam['c'], self::SLOT_ITEM_CLASSES) ? $getParam['c'] : 'sword';

--- a/src/classes/model/ItemModel.php
+++ b/src/classes/model/ItemModel.php
@@ -28,11 +28,14 @@ class ItemModel extends Model
         , IC.name_key item_class_name_key
         , IC.name_en item_class_name
         , I.base_item_id
+        , I.class_flactuable
+        , I.class_flactuable_base_id
         , I.image_name
         , I.name_key
         , I.name_en
         , I.name_ja
         , I.rarity
+        , I.storable_count
         , I.skill_en
         , I.skill_axe_en
         , I.skill_sword_en
@@ -125,10 +128,12 @@ class ItemModel extends Model
         , IC.name_en item_class
         , I.base_item_id
         , I.class_flactuable
+        , I.class_flactuable_base_id
         , I.name_key
         , I.name_en
         , I.name_ja
         , I.rarity
+        , I.storable_count
         , I.image_name
         SQL;
 
@@ -603,10 +608,12 @@ class ItemModel extends Model
                 'item_class' => $result['item_class'],
                 'base_item_id' => $result['base_item_id'],
                 'class_flactuable' => $result['class_flactuable'],
+                'class_flactuable_base_id' => $result['class_flactuable_base_id'],
                 'name' => $this->i18n->s($result['name_key']),
                 'name_en' => $result['name_en'],
                 'name_ja' => $result['name_ja'],
                 'rarity' => $result['rarity'],
+                'storable_count' => $result['storable_count'],
                 'image_name' => $result['image_name'],
                 'description' => $this->i18n->s($result['description_key']),
                 'note' => $result['note'],
@@ -690,10 +697,12 @@ class ItemModel extends Model
                 'item_class' => $result['item_class'],
                 'base_item_id' => $result['base_item_id'],
                 'class_flactuable' => $result['class_flactuable'],
+                'class_flactuable_base_id' => $result['class_flactuable_base_id'],
                 'name' => $this->i18n->s($result['name_key']),
                 'name_en' => $result['name_en'],
                 'name_ja' => $result['name_ja'],
                 'rarity' => $result['rarity'],
+                'storable_count' => $result['storable_count'],
                 'image_name' => $result['image_name'],
                 'price' => $result['price'],
             ];
@@ -732,12 +741,15 @@ class ItemModel extends Model
                 $item['item_class_id'] = $result['item_class_id'];
                 $item['item_class_name'] = strtolower($result['item_class_name']);
                 $item['base_item_id'] = $result['base_item_id'];
+                $item['class_flactuable'] = $result['class_flactuable'];
+                $item['class_flactuable_base_id'] = $result['class_flactuable_base_id'];
                 $item['image_name'] = ($result['image_name'] === null)
                     ? "item_noimg.png" : $result['image_name'];
                 $item['name'] = $this->i18n->s($result['name_key']);
                 $item['name_en'] = $result['name_en'];
                 $item['name_ja'] = $result['name_ja'];
                 $item['rarity'] = $result['rarity'];
+                $item['storable_count'] = $result['storable_count'];
                 $item['skill_en'] = $result['skill_en'];
                 $item['skill_axe_en'] = $result['skill_axe_en'];
                 $item['skill_sword_en'] = $result['skill_sword_en'];
@@ -948,10 +960,12 @@ class ItemModel extends Model
                 'item_class' => $result['item_class'],
                 'base_item_id' => $result['base_item_id'],
                 'class_flactuable' => $result['class_flactuable'],
+                'class_flactuable_base_id' => $result['class_flactuable_base_id'],
                 'name' => $this->i18n->s($result['name_key']),
                 'name_en' => $result['name_en'],
                 'name_ja' => $result['name_ja'],
                 'rarity' => $result['rarity'],
+                'storable_count' => $result['storable_count'],
                 'image_name' => $result['image_name'],
             ];
         }

--- a/src/resources/en.yaml
+++ b/src/resources/en.yaml
@@ -8,6 +8,7 @@ common:
   unit_sec: 'sec'
   tooltip_class_stats_description: 'Character class abbreviation'
   tooltip_stats_short_name_description: 'Stats abbreviation'
+  tooltip_item_obtained: 'By registering an item as obtained, you will be able to filter obtained items within the simulator.'
   loading: 'Loading...'
   currency_unit: 'G'
   currency_unit_full: 'Gold'
@@ -127,6 +128,7 @@ items:
 
 items_detail:
   sell_price: 'Sell Price'
+  obtained: 'Obtained'
   floors: 'Floors'
   banana_trade: 'Banana Trade'
   floor_treasures: 'Floor Treasures'
@@ -187,6 +189,7 @@ simulator_item_modal:
   rarity_common: 'Common'
   rarity_rare: 'Rare'
   rarity_artifact: 'Artifact'
+  obtained_items: 'Obtained Items'
   search_submit: 'Submit'
 
 simulator_save_modal:

--- a/src/resources/ja.yaml
+++ b/src/resources/ja.yaml
@@ -8,6 +8,7 @@ common:
   unit_sec: '秒'
   tooltip_class_stats_description: 'クラス別スタッツの表記'
   tooltip_stats_short_name_description: 'スタッツの略称表記'
+  tooltip_item_obtained: '所持済みアイテムに登録することで、シミュレータで所持済みアイテムを検索できます。'
   loading: '読み込み中…'
   currency_unit: 'G'
   currency_unit_full: 'ゴールド'
@@ -127,6 +128,7 @@ items:
 
 items_detail:
   sell_price: '売却価格'
+  obtained: '所持済み'
   floors: 'レアドロップ'
   banana_trade: 'バナナ交換'
   floor_treasures: '宝箱'
@@ -187,6 +189,7 @@ simulator_item_modal:
   rarity_common: 'ノーマル'
   rarity_rare: 'レア'
   rarity_artifact: 'アーティファクト'
+  obtained_items: '所持済みのみ'
   search_submit: '決定'
 
 simulator_save_modal:

--- a/src/resources/pt-BR.yaml
+++ b/src/resources/pt-BR.yaml
@@ -8,6 +8,7 @@ common:
   unit_sec: 'seg'
   tooltip_class_stats_description: 'Abreviação da classe de personagem'
   tooltip_stats_short_name_description: 'Abreviação do atributo'
+  tooltip_item_obtained: 'By registering an item as obtained, you will be able to filter obtained items within the simulator.'
   loading: 'Carregando...'
   currency_unit: 'G'
   currency_unit_full: 'Ouro'
@@ -127,6 +128,7 @@ items:
 
 items_detail:
   sell_price: 'Preço de Venda'
+  obtained: 'Obtained'
   floors: 'Pisos'
   banana_trade: 'Troca por Banana'
   floor_treasures: 'Tesouros do Andar'
@@ -187,6 +189,7 @@ simulator_item_modal:
   rarity_common: 'Comum'
   rarity_rare: 'Raro'
   rarity_artifact: 'Artefato'
+  obtained_items: 'Obtained Items'
   search_submit: 'Submeter'
 
 simulator_save_modal:

--- a/src/resources/zh-CN.yaml
+++ b/src/resources/zh-CN.yaml
@@ -8,6 +8,7 @@ common:
   unit_sec: '秒'
   tooltip_class_stats_description: '每位大师的缩写'
   tooltip_stats_short_name_description: '素质的缩写'
+  tooltip_item_obtained: '透过将项目注册为已获得的物品，您可以在模拟器中搜寻已获得的物品。'
   loading: '加载中...'
   currency_unit: 'G'
   currency_unit_full: '黄金'
@@ -127,6 +128,7 @@ items:
 
 items_detail:
   sell_price: '售价'
+  obtained: '已获得'
   floors: '稀有物品'
   banana_trade: '香蕉换'
   floor_treasures: '宝箱'
@@ -187,6 +189,7 @@ simulator_item_modal:
   rarity_common: '普通物品'
   rarity_rare: '稀有物品'
   rarity_artifact: '魔物特制'
+  obtained_items: '已获得物品'
   search_submit: '提交'
 
 simulator_save_modal:

--- a/src/resources/zh-TW.yaml
+++ b/src/resources/zh-TW.yaml
@@ -8,6 +8,7 @@ common:
   unit_sec: '秒'
   tooltip_class_stats_description: '每位大師的縮寫'
   tooltip_stats_short_name_description: '素質的縮寫'
+  tooltip_item_obtained: '透過將項目註冊為已獲得的物品，您可以在模擬器中搜尋已獲得的物品。'
   loading: '載入中...'
   currency_unit: 'G'
   currency_unit_full: '黃金'
@@ -127,6 +128,7 @@ items:
 
 items_detail:
   sell_price: '售價'
+  obtained: '已獲得'
   floors: '稀有物品'
   banana_trade: '香蕉換'
   floor_treasures: '寶箱'
@@ -187,6 +189,7 @@ simulator_item_modal:
   rarity_common: '普通物品'
   rarity_rare: '稀有物品'
   rarity_artifact: '魔物特製'
+  obtained_items: '已獲得物品'
   search_submit: '提交'
 
 simulator_save_modal:

--- a/templates/common/tooltipObtainedItems.phtml
+++ b/templates/common/tooltipObtainedItems.phtml
@@ -1,0 +1,3 @@
+<div class='text-left text-light'>
+  <div><?= $l->s('common.tooltip_item_obtained') ?></div>
+</div>

--- a/templates/items/detail.phtml
+++ b/templates/items/detail.phtml
@@ -24,14 +24,15 @@
             <div><?= $l->s('items_detail.sell_price') ?>&nbsp;:&nbsp;<span id="sell-price">?</span>&nbsp;<?= $l->s('common.currency_unit_full') ?></div>
           </div>
         </div>
-        <div class="row">
+        <div id="detail-obtained-item-row" class="row">
           <div class="col-12 mb-3 small">
             <div class="form-check form-check-inline">
-              <label class="form-check-label pr-1" for="obtained-item-1"><?= $l->s('items_detail.obtained') ?></label>
-              <input id="obtained-item-1" class="form-check-input checkbox-obtained-item" type="checkbox" />
-              <input id="obtained-item-2" class="form-check-input checkbox-obtained-item" type="checkbox" />
+              <label id="obtained-item-checkbox-label" class="form-check-label pr-1" for="obtained-item-1"><?= $l->s('items_detail.obtained') ?></label>
               <a href="javascript:void(0);" id="tooltip-obtained-items" class="text-light pl-1" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipObtainedItems.phtml', ['l' => $l]) ?>"><i class="fas fa-question-circle"></i></a>
             </div>
+            <template id="obtained-item-checkbox-input">
+              <input id="obtained-item" class="form-check-input checkbox-obtained-item" type="checkbox" />
+            </template>
           </div>
         </div>
         <div class="row">

--- a/templates/items/detail.phtml
+++ b/templates/items/detail.phtml
@@ -25,6 +25,16 @@
           </div>
         </div>
         <div class="row">
+          <div class="col-12 mb-3 small">
+            <div class="form-check form-check-inline">
+              <label class="form-check-label pr-1" for="obtained-item-1"><?= $l->s('items_detail.obtained') ?></label>
+              <input id="obtained-item-1" class="form-check-input checkbox-obtained-item" type="checkbox" />
+              <input id="obtained-item-2" class="form-check-input checkbox-obtained-item" type="checkbox" />
+              <a href="javascript:void(0);" id="tooltip-obtained-items" class="text-light pl-1" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipObtainedItems.phtml', ['l' => $l]) ?>"><i class="fas fa-question-circle"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="row">
           <div class="col-12 mb-3">
             <div><?= $l->s('items_detail.floors') ?></div>
             <ul class="list-inline m-0 pl-1 small" id="detail-floors">

--- a/templates/items/row.phtml
+++ b/templates/items/row.phtml
@@ -1,4 +1,4 @@
-<div class="card mb-2 bg-darkblue selectable" id="<?= $item['item_id'] ?>" data-itemid="<?= $item['item_id'] ?>" data-price="<?= $item['price'] ?>">
+<div class="card mb-2 bg-darkblue selectable" id="<?= $item['item_id'] ?>" data-itemid="<?= $item['item_id'] ?>" data-price="<?= $item['price'] ?>" data-storable-count="<?= $item['storable_count'] ?>" data-item-class-flactuable="<?= $item['class_flactuable'] ?>" data-item-class-flactuable-id="<?= $item['class_flactuable_base_id'] ?>">
   <div class="row">
     <div class="col-12 col-md-3 text-center my-3">
       <img src="/img/item/<?= $item['image_name'] ?>" alt="<?= $item['name'] ?>" class="item-detail" />

--- a/templates/simulator/itemModal.phtml
+++ b/templates/simulator/itemModal.phtml
@@ -26,7 +26,7 @@
                 <input id="search-rarity-artifact" class="form-check-input" type="checkbox" value="true" />
                 <label class="form-check-label small artifact" for="search-rarity-artifact"><?= $l->s('simulator_item_modal.rarity_artifact') ?></label>
               </div>
-              <div class="form-check form-check-inline">
+              <div id="search-obtained-items-form" class="form-check form-check-inline">
                 <input id="search-obtained-items" class="form-check-input" type="checkbox" value="true" />
                 <label class="form-check-label small" for="search-obtained-items"><?= $l->s('simulator_item_modal.obtained_items') ?></label>
                 <a href="javascript:void(0);" id="tooltip-obtained-items" class="text-light pl-1" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipObtainedItems.phtml', ['l' => $l]) ?>"><i class="fas fa-question-circle"></i></a>

--- a/templates/simulator/itemModal.phtml
+++ b/templates/simulator/itemModal.phtml
@@ -26,6 +26,11 @@
                 <input id="search-rarity-artifact" class="form-check-input" type="checkbox" value="true" />
                 <label class="form-check-label small artifact" for="search-rarity-artifact"><?= $l->s('simulator_item_modal.rarity_artifact') ?></label>
               </div>
+              <div class="form-check form-check-inline">
+                <input id="search-obtained-items" class="form-check-input" type="checkbox" value="true" />
+                <label class="form-check-label small" for="search-obtained-items"><?= $l->s('simulator_item_modal.obtained_items') ?></label>
+                <a href="javascript:void(0);" id="tooltip-obtained-items" class="text-light pl-1" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipObtainedItems.phtml', ['l' => $l]) ?>"><i class="fas fa-question-circle"></i></a>
+              </div>
               <div class="text-right">
                 <a href="javascript:void(0);" class="lemonchiffon" id="link-search-submit" data-item-slot=""><i class="far fa-check-circle"></i><?= $l->s('simulator_item_modal.search_submit') ?></a>
               </div>


### PR DESCRIPTION
# 新機能 : アイテム所持済みチェック

- アイテムデータの詳細モーダルでアイテムの入手済みチェックができる
  - チェックをするとローカルストレージに入手済みアイテムを保存する
  - 保管可能数に応じてチェックボックスの数が変動する
- シミュレータで入手済みアイテムのみを検索する機能を追加
  - 複数個装備できるアイテムについては、保存された所持数分だけ選択できる

# 既存機能の変更

- シミュレータのアイテム検索条件を、ナマモノとパペット以外の種別では保存するよう変更
- パペットのデフォルト検索条件を全アイテムに変更