### PR TITLE
シミュレータのアイテム選択モーダルにアイテム名検索機能を追加

### DIFF
--- a/public/js/simulator.js
+++ b/public/js/simulator.js
@@ -714,10 +714,19 @@ $(function () {
               return target.data('slot-index') != slotIndex && storableItemId == slotItemStorableItemId;
             }).length < obtainedItems.items[storableItemId];
           }
-          return obtainedItems.items[storableItemId] > 0;
-        } else {
-          return true;
+          if (obtainedItems.items[storableItemId] <= 0) {
+            return false;
+          }
         }
+
+        // アイテム名でフィルタ
+        if ($("#search-item-name").val().length > 0) {
+          const itemName = $("#search-item-name").val().toLowerCase();
+          if (item.name.toLowerCase().indexOf(itemName) == -1) {
+            return false;
+          }
+        }
+        return true;
       }));
       $("#scroll-loading").removeClass("d-none").addClass("d-flex");
 

--- a/src/resources/en.yaml
+++ b/src/resources/en.yaml
@@ -194,6 +194,7 @@ simulator_item_modal:
   rarity_rare: 'Rare'
   rarity_artifact: 'Artifact'
   obtained_items: 'Obtained Items'
+  item_name: 'Item Name'
   search_submit: 'Submit'
 
 simulator_save_modal:

--- a/src/resources/ja.yaml
+++ b/src/resources/ja.yaml
@@ -194,6 +194,7 @@ simulator_item_modal:
   rarity_rare: 'レア'
   rarity_artifact: 'アーティファクト'
   obtained_items: '所持済みのみ'
+  item_name: 'アイテム名'
   search_submit: '決定'
 
 simulator_save_modal:

--- a/src/resources/pt-BR.yaml
+++ b/src/resources/pt-BR.yaml
@@ -194,6 +194,7 @@ simulator_item_modal:
   rarity_rare: 'Raro'
   rarity_artifact: 'Artefato'
   obtained_items: 'Obtained Items'
+  item_name: 'Nome do item'
   search_submit: 'Submeter'
 
 simulator_save_modal:

--- a/src/resources/zh-CN.yaml
+++ b/src/resources/zh-CN.yaml
@@ -194,6 +194,7 @@ simulator_item_modal:
   rarity_rare: '稀有物品'
   rarity_artifact: '魔物特制'
   obtained_items: '已获得物品'
+  item_name: '物品名称'
   search_submit: '提交'
 
 simulator_save_modal:

--- a/src/resources/zh-TW.yaml
+++ b/src/resources/zh-TW.yaml
@@ -194,6 +194,7 @@ simulator_item_modal:
   rarity_rare: '稀有物品'
   rarity_artifact: '魔物特製'
   obtained_items: '已獲得物品'
+  item_name: '物品名稱'
   search_submit: '提交'
 
 simulator_save_modal:

--- a/templates/simulator/itemModal.phtml
+++ b/templates/simulator/itemModal.phtml
@@ -31,6 +31,9 @@
                 <label class="form-check-label small" for="search-obtained-items"><?= $l->s('simulator_item_modal.obtained_items') ?></label>
                 <a href="javascript:void(0);" id="tooltip-obtained-items" class="text-light pl-1" data-toggle="tooltip" data-placement="top" data-html="true" title="<?= $this->fetch('common/tooltipObtainedItems.phtml', ['l' => $l]) ?>"><i class="fas fa-question-circle"></i></a>
               </div>
+              <div class="form-text">
+                <input id="search-item-name" class="form-control" type="text" maxlength="32" placeholder="<?= $l->s('simulator_item_modal.item_name') ?>" />
+              </div>
               <div class="text-right">
                 <a href="javascript:void(0);" class="lemonchiffon" id="link-search-submit" data-item-slot=""><i class="far fa-check-circle"></i><?= $l->s('simulator_item_modal.search_submit') ?></a>
               </div>


### PR DESCRIPTION
# 機能追加 : シミュレータのアイテム名検索

- アイテム名を部分一致で検索する
- 英字の大文字小文字は区別しない
- 他の検索条件がある場合にはAND検索とする
- 入力した内容はページの読み込みがされるまで維持され、アイテム選択モーダルを開いた時点で反映される
- 複数の検索条件に対応するため、所持済みアイテム検索のロジックを変更
  - 所持済みアイテムにある場合trueを返す→ない場合falseを返す